### PR TITLE
CDP-580: Add taxonomy term synonym mapping support

### DIFF
--- a/src/api/resources/course/routes.js
+++ b/src/api/resources/course/routes.js
@@ -3,18 +3,39 @@ import controller from './controller';
 import CourseModel from './model';
 import { transferCtrl, deleteCtrl } from '../../../middleware/transfer';
 import asyncResponse from '../../../middleware/asyncResponse';
+import {
+  translateCategories,
+  keywordCategories,
+  synonymCategories
+} from '../../../middleware/categories';
 
 const router = new Router();
 
 router.param( 'uuid', controller.setRequestDoc );
 
 // Route: /v1/course
-router.route( '/' ).post( asyncResponse, transferCtrl( CourseModel ), controller.indexDocument );
+router
+  .route( '/' )
+  .post(
+    asyncResponse,
+    transferCtrl( CourseModel ),
+    keywordCategories,
+    synonymCategories,
+    translateCategories( CourseModel ),
+    controller.indexDocument
+  );
 
 // Route: /v1/course/[uuid]
 router
   .route( '/:uuid' )
-  .put( asyncResponse, transferCtrl( CourseModel ), controller.updateDocumentById )
+  .put(
+    asyncResponse,
+    transferCtrl( CourseModel ),
+    keywordCategories,
+    synonymCategories,
+    translateCategories( CourseModel ),
+    controller.updateDocumentById
+  )
   .get( controller.getDocumentById )
   .delete( deleteCtrl( CourseModel ), controller.deleteDocumentById );
 

--- a/src/api/resources/post/routes.js
+++ b/src/api/resources/post/routes.js
@@ -3,8 +3,11 @@ import controller from './controller';
 import PostModel from './model';
 import { transferCtrl, deleteCtrl } from '../../../middleware/transfer';
 import asyncResponse from '../../../middleware/asyncResponse';
-import cleanTempFilesCtrl from '../../../middleware/cleanTempFiles';
-import { translateCategories, keywordCategories } from '../../../middleware/categories';
+import {
+  translateCategories,
+  keywordCategories,
+  synonymCategories
+} from '../../../middleware/categories';
 
 const router = new Router();
 
@@ -17,6 +20,7 @@ router
     asyncResponse,
     transferCtrl( PostModel ),
     keywordCategories,
+    synonymCategories,
     translateCategories( PostModel ),
     controller.indexDocument
   );
@@ -27,6 +31,8 @@ router
   .put(
     asyncResponse,
     transferCtrl( PostModel ),
+    keywordCategories,
+    synonymCategories,
     translateCategories( PostModel ),
     controller.updateDocumentById
   )

--- a/src/api/resources/taxonomy/model.js
+++ b/src/api/resources/taxonomy/model.js
@@ -62,6 +62,32 @@ class Taxonomy extends AbstractModel {
     return result;
   }
 
+  /**
+   * Searches Elasticsearch for a terms that have a loose match in the
+   * synonymMapping property.
+   *
+   * @param name
+   * @returns {Promise<*>}
+   */
+  async findDocsBySynonym( name ) {
+    const result = await this.client
+      .search( {
+        index: this.index,
+        type: this.type,
+        body: {
+          query: {
+            match: {
+              synonymMapping: {
+                query: name
+              }
+            }
+          }
+        }
+      } )
+      .catch( err => err );
+    return result;
+  }
+
   async translateTermById( id, locale = 'en' ) {
     const result = await this.findDocumentById( id ).then( parser.parseGetResult( id ) );
     if ( result.language[locale] ) return result.language[locale];

--- a/src/api/test/index.js
+++ b/src/api/test/index.js
@@ -1,16 +1,9 @@
 import { Router } from 'express';
-import TaxonomyModel from '../resources/taxonomy/model';
-import controllers from '../modules/elastic/controller';
 
 const router = new Router();
 
 // eslint-disable-next-line no-unused-vars
-router.get( '/', async ( req, res ) => {
-  controllers
-    .findTermByName( new TaxonomyModel(), 'about america' )
-    .then( result => res.json( result ) )
-    .catch( err => res.json( err ) );
-} );
+router.get( '/', async ( req, res ) => {} );
 
 // Post {url: '', title: ''} to upload the file located at URL to S3
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
Created synonomCategories middleware for plucking out keywords that match to terms based on synonymMapping property.
Updated course and post routes.
Added findDocsBySynonym to the taxonomy model.
Also cleaned out test stuff in the test endpoint.