### PR TITLE
CDP-580: Add taxonomy term synonym mapping support

### DIFF
--- a/src/api/resources/course/routes.js
+++ b/src/api/resources/course/routes.js
@@ -3,18 +3,39 @@ import controller from './controller';
 import CourseModel from './model';
 import { transferCtrl, deleteCtrl } from '../../../middleware/transfer';
 import asyncResponse from '../../../middleware/asyncResponse';
+import {
+  translateCategories,
+  keywordCategories,
+  synonymCategories
+} from '../../../middleware/categories';
 
 const router = new Router();
 
 router.param( 'uuid', controller.setRequestDoc );
 
 // Route: /v1/course
-router.route( '/' ).post( asyncResponse, transferCtrl( CourseModel ), controller.indexDocument );
+router
+  .route( '/' )
+  .post(
+    asyncResponse,
+    transferCtrl( CourseModel ),
+    keywordCategories,
+    synonymCategories,
+    translateCategories( CourseModel ),
+    controller.indexDocument
+  );
 
 // Route: /v1/course/[uuid]
 router
   .route( '/:uuid' )
-  .put( asyncResponse, transferCtrl( CourseModel ), controller.updateDocumentById )
+  .put(
+    asyncResponse,
+    transferCtrl( CourseModel ),
+    keywordCategories,
+    synonymCategories,
+    translateCategories( CourseModel ),
+    controller.updateDocumentById
+  )
   .get( controller.getDocumentById )
   .delete( deleteCtrl( CourseModel ), controller.deleteDocumentById );
 

--- a/src/api/resources/course/routes.js
+++ b/src/api/resources/course/routes.js
@@ -5,7 +5,7 @@ import { transferCtrl, deleteCtrl } from '../../../middleware/transfer';
 import asyncResponse from '../../../middleware/asyncResponse';
 import {
   translateCategories,
-  keywordCategories,
+  tagCategories,
   synonymCategories
 } from '../../../middleware/categories';
 
@@ -19,7 +19,7 @@ router
   .post(
     asyncResponse,
     transferCtrl( CourseModel ),
-    keywordCategories,
+    tagCategories,
     synonymCategories,
     translateCategories( CourseModel ),
     controller.indexDocument
@@ -31,7 +31,7 @@ router
   .put(
     asyncResponse,
     transferCtrl( CourseModel ),
-    keywordCategories,
+    tagCategories,
     synonymCategories,
     translateCategories( CourseModel ),
     controller.updateDocumentById

--- a/src/api/resources/post/routes.js
+++ b/src/api/resources/post/routes.js
@@ -5,7 +5,7 @@ import { transferCtrl, deleteCtrl } from '../../../middleware/transfer';
 import asyncResponse from '../../../middleware/asyncResponse';
 import {
   translateCategories,
-  keywordCategories,
+  tagCategories,
   synonymCategories
 } from '../../../middleware/categories';
 
@@ -19,7 +19,7 @@ router
   .post(
     asyncResponse,
     transferCtrl( PostModel ),
-    keywordCategories,
+    tagCategories,
     synonymCategories,
     translateCategories( PostModel ),
     controller.indexDocument
@@ -31,7 +31,7 @@ router
   .put(
     asyncResponse,
     transferCtrl( PostModel ),
-    keywordCategories,
+    tagCategories,
     synonymCategories,
     translateCategories( PostModel ),
     controller.updateDocumentById

--- a/src/api/resources/post/routes.js
+++ b/src/api/resources/post/routes.js
@@ -3,7 +3,11 @@ import controller from './controller';
 import PostModel from './model';
 import { transferCtrl, deleteCtrl } from '../../../middleware/transfer';
 import asyncResponse from '../../../middleware/asyncResponse';
-import { translateCategories, keywordCategories } from '../../../middleware/categories';
+import {
+  translateCategories,
+  keywordCategories,
+  synonymCategories
+} from '../../../middleware/categories';
 
 const router = new Router();
 
@@ -16,6 +20,7 @@ router
     asyncResponse,
     transferCtrl( PostModel ),
     keywordCategories,
+    synonymCategories,
     translateCategories( PostModel ),
     controller.indexDocument
   );
@@ -26,6 +31,8 @@ router
   .put(
     asyncResponse,
     transferCtrl( PostModel ),
+    keywordCategories,
+    synonymCategories,
     translateCategories( PostModel ),
     controller.updateDocumentById
   )

--- a/src/api/resources/taxonomy/model.js
+++ b/src/api/resources/taxonomy/model.js
@@ -62,6 +62,32 @@ class Taxonomy extends AbstractModel {
     return result;
   }
 
+  /**
+   * Searches Elasticsearch for a terms that have a loose match in the
+   * synonymMapping property.
+   *
+   * @param name
+   * @returns {Promise<*>}
+   */
+  async findDocsBySynonym( name ) {
+    const result = await this.client
+      .search( {
+        index: this.index,
+        type: this.type,
+        body: {
+          query: {
+            match: {
+              synonymMapping: {
+                query: name
+              }
+            }
+          }
+        }
+      } )
+      .catch( err => err );
+    return result;
+  }
+
   async translateTermById( id, locale = 'en' ) {
     const result = await this.findDocumentById( id ).then( parser.parseGetResult( id ) );
     if ( result.language[locale] ) return result.language[locale];

--- a/src/api/test/index.js
+++ b/src/api/test/index.js
@@ -1,16 +1,9 @@
 import { Router } from 'express';
-import TaxonomyModel from '../resources/taxonomy/model';
-import controllers from '../modules/elastic/controller';
 
 const router = new Router();
 
 // eslint-disable-next-line no-unused-vars
-router.get( '/', async ( req, res ) => {
-  controllers
-    .findTermByName( new TaxonomyModel(), 'about america' )
-    .then( result => res.json( result ) )
-    .catch( err => res.json( err ) );
-} );
+router.get( '/', async ( req, res ) => {} );
 
 // Post {url: '', title: ''} to upload the file located at URL to S3
 // eslint-disable-next-line no-unused-vars

--- a/src/middleware/categories.js
+++ b/src/middleware/categories.js
@@ -59,50 +59,50 @@ export const translateCategories = Model => async ( req, res, next ) => {
 };
 
 /**
- * Searches for terms that match the provided keywords in the provided locale.
- * If a term is matched, the keyword is removed and the term ID is added to the categories property.
+ * Searches for terms that match the provided tags in the provided locale.
+ * If a term is matched, the tag is removed and the term ID is added to the categories property.
  *
  * @param req
  * @param res
  * @param next
  * @returns {Promise<*>}
  */
-export const keywordCategories = async ( req, res, next ) => {
+export const tagCategories = async ( req, res, next ) => {
   const model = new TaxonomyModel();
   const body = req.body; // eslint-disable-line prefer-destructuring
-  if ( 'keywords' in body !== true ) return next();
-  const keywords = [];
+  if ( 'tags' in body !== true ) return next();
+  const tags = [];
   const terms = body.categories || [];
-  body.keywords = body.keywords.map( kw => kw.toLowerCase() );
-  await body.keywords.reduce(
-    async ( accumP, keyword ) =>
+  body.tags = body.tags.map( kw => kw.toLowerCase() );
+  await body.tags.reduce(
+    async ( accumP, tag ) =>
       accumP.then( async () => {
         await controllers
-          .findDocByTerm( model, keyword )
+          .findDocByTerm( model, tag )
           .then( ( result ) => {
             if ( !result ) {
-              console.log( 'no term for', keyword );
-              keywords.push( keyword );
+              console.log( 'no term for', tag );
+              tags.push( tag );
             } else if ( !terms.includes( result._id ) ) {
               terms.push( result._id );
             }
           } )
           .catch( () => {
-            console.log( 'no term for', keyword );
-            keywords.push( keyword );
+            console.log( 'no term for', tag );
+            tags.push( tag );
           } );
         return {};
       } ),
     Promise.resolve( {} )
   );
-  body.keywords = keywords;
+  body.tags = tags;
   body.categories = terms;
   next();
 };
 
 /**
- * Searches for taxonomy terms that have a match for a keyword in the synonymMapping
- * property. If a match is found, the keyword is removed and the term ID is added to the
+ * Searches for taxonomy terms that have a match for a tag in the synonymMapping
+ * property. If a match is found, the tag is removed and the term ID is added to the
  * categories property.
  *
  * @param req
@@ -113,23 +113,23 @@ export const keywordCategories = async ( req, res, next ) => {
 export const synonymCategories = async ( req, res, next ) => {
   const model = new TaxonomyModel();
   const body = req.body; // eslint-disable-line prefer-destructuring
-  if ( 'keywords' in body !== true ) return next();
-  const keywords = [];
+  if ( 'tags' in body !== true ) return next();
+  const tags = [];
   const terms = body.categories || [];
-  await body.keywords.reduce(
-    async ( accumP, keyword ) =>
+  await body.tags.reduce(
+    async ( accumP, tag ) =>
       accumP.then( async () => {
         const results = await model
-          .findDocsBySynonym( keyword )
+          .findDocsBySynonym( tag )
           .then( parser.parseFindResult() )
           .catch( () => {
-            console.log( 'no term for', keyword );
-            keywords.push( keyword );
+            console.log( 'no term for', tag );
+            tags.push( tag );
           } );
         if ( results ) {
           const result = results[0];
           if ( !terms.includes( result._id ) ) {
-            console.log( `matched ${keyword} with ${result.language.en}` );
+            console.log( `matched ${tag} with ${result.language.en}` );
             terms.push( result._id );
           }
         }
@@ -137,7 +137,7 @@ export const synonymCategories = async ( req, res, next ) => {
       } ),
     Promise.resolve( {} )
   );
-  body.keywords = keywords;
+  body.tags = tags;
   body.categories = terms;
   next();
 };


### PR DESCRIPTION
Created synonomCategories middleware for plucking out keywords that match to terms based on synonymMapping property.
Updated course and post routes.
Added findDocsBySynonym to the taxonomy model.
Also cleaned out test stuff in the test endpoint.

ADDITIONALLY: Switched to using "tags" property instead of "keywords"