### PR TITLE
CDP-605: Update taxonomy import to include translations

### DIFF
--- a/imports/cdp_taxonomy.csv
+++ b/imports/cdp_taxonomy.csv
@@ -1,223 +1,239 @@
-Parent (categories from card sort),Child Term (cards from sort),Terms with Multiple Parents,Skip - Child Term is a Parent Term ,Synonyms - Alternatives from card sort
-About America,,,,About United States | About U.S. | About U.S.A | About USA | Info About U.S  | Info About U.S.A | Info About U.S.A
-,about america,,Parent Term,
-,american culture,,,United States culture | US culture | U.S. culture | U.S.A culture
-,diversity,MULTIPLE,,
-,employment legislation,,,
-,LGBT| ,MULTIPLE,,LGBT | lesbian | gay | bisexual | transgender | intersex 
-,english learning,MULTIPLE,,
-,entertainment,MULTIPLE,,
-,exchange,MULTIPLE,,
-,leadership,MULTIPLE,,
-,leadership & community action,MULTIPLE,,
-,people,MULTIPLE,,
-,retirement,MULTIPLE,,
-,social learning,MULTIPLE,,
-,sport event,MULTIPLE,,
-,study in the U.S.,MULTIPLE,,
-,travel to the U.S. ,MULTIPLE,,
-,U.S. Government,MULTIPLE,,
-,values,MULTIPLE,,
-Arts & Culture,,,,Arts & Entertainment | Arts and Society
-,arts,,Parent Term,
-,culture,,Parent Term,
-,ceremony,MULTIPLE,,
-,entertainment,MULTIPLE,,
-,people,MULTIPLE,,
-,sport event,MULTIPLE,,
-,travel to the U.S. ,MULTIPLE,,
-Democracy & Civil Society,,,,
-,anti-corruption,MULTIPLE,,
-,civic leadership,,,
-,civil society,,Parent Term,
-,civil unrest,MULTIPLE,,
-,communities,,,
-,democracy,MULTIPLE,Parent Term,
-,detainees,,,
-,development,MULTIPLE,,
-,diversity,MULTIPLE,,
-,drug use,MULTIPLE,,
-,election,MULTIPLE,,
-,emergency incident,MULTIPLE,,
-,emergency planning,MULTIPLE,,
-,emergency response,MULTIPLE,,
-,family,,,
-,foreign aid,,,
-,government policy,MULTIPLE,,
-,humankind,,,mankind
-,international relations,MULTIPLE,,
-,interreligious dialogue,MULTIPLE,,
-,law enforcement,,,
-,leadership,MULTIPLE,,
-,leadership & community action,MULTIPLE,,
-,non-governmental organization (NGO),MULTIPLE,,
-,post-war reconstruction,MULTIPLE,,
-,prisoners,MULTIPLE,,
-,public management,,,
-,social condition,MULTIPLE,,
-,social problem,,,
-,state relations,MULTIPLE,,
-,transparency,MULTIPLE,,
-,women & girls,MULTIPLE,,
-,women's issues,MULTIPLE,,
-,women’s empowerment,MULTIPLE,,
+Parent (categories from card sort),Child Term (cards from sort),Terms with Multiple Parents,Skip - Child Term is a Parent Term ,Synonyms - Alternatives from card sort,Lang: Spanish | es-es,Lang: French | fr-fr,Lang: Portuguese (Brazil) | pt-br,Lang: Arabic | ar,Lang: Persian | fa-ir,Lang: Chinese | zh-cn,Lang: Russian | ru-ru,Lang: Bahasa Indonesian | id-id,Lang: Urdu | ur
+About America,,,,About United States | About U.S. | About U.S.A | About USA | Info About U.S  | Info About U.S.A | Info About U.S.A,conozca Estados Unidos,Amérique,sobre os Estados Unidos,عن أميركا,درباره آمریکا,美国概览,Об Америке,Tentang Amerika,امریکہ سے متعلق
+,about america,,Parent Term,,conozca Estados Unidos,Amérique,sobre os Estados Unidos,عن أميركا,درباره آمریکا,美国概览,Об Америке,Tentang Amerika,امریکہ سے متعلق
+,american culture,,,United States culture | US culture | U.S. culture | U.S.A culture,Cultura de Estados Unidos,Culture américaine,Cultura americana,الثقافة الأميركية,فرهنگ آمریکایی,美国文化,Американская культура,Budaya Amerika,امریکی ثقافت
+,diversity,MULTIPLE,,,diversidad,Diversité,diversidade,التنوع,گوناگونی,多样性,Разнообразие,keberagaman,تنوع
+,employment legislation,,,,legislación laboral,"législation du travail
+",legislação trabalhista,تشريعات العمل,قانون کار,就業立法,трудовое законодательство,undang-undang ketenagakerjaan,روزگار کے قانون سازی
+,LGBTI,,,LGBT | lesbian | gay | bisexual | transgender | intersex ,LGBTI,LGBTI,LGBT,المثليون ومزدوجو الميل الجنسي ومغايرو الهوية الجنسانية,دگرباشان,LGBTI,ЛГБТИ,LGBTI,ایل جی بی ٹی آئی
+,english learning,MULTIPLE,,,aprendizaje del idioma inglés,Anglais langue étrangère,aprendizagem de Inglês,تعلم اللغة الإنجليزية,یادگیری زبان انگلیسی,英语学习,Изучение английского языка,pembelajaran bahasa Inggris,انگریزی سیکھنا
+,entertainment,MULTIPLE,,,entretenimiento,divertissement,entretenimento,وسائل الترفيه,سرگرمی,娛樂,развлекательная программа,hiburan,تفریح
+,exchange,MULTIPLE,,,intercambiar,échange,troca,تبادل,تبادل,交換,обмен,bertukar,تبادلہ
+,leadership,MULTIPLE,,,liderazgo,direction,Liderança,قيادة,رهبری,領導,руководство,kepemimpinan,قیادت
+,leadership & community action,MULTIPLE,,,Liderazgo y acción comunitaria,leadership et action communautaire,liderança e ação comunitária,القيادة والعمل المجتمعي,"رهبری و اقدامات اجتماعی
+",領導力和社區行動,руководство и действия сообщества,kepemimpinan & aksi komunitas,قیادت اور کمیونٹی کی کارروائی
+,people,MULTIPLE,,,gente,gens,pessoas,اشخاص,مردم,人,люди,orang-orang,لوگ
+,retirement,MULTIPLE,,,Jubilación,retraite,aposentadoria,تقاعد,بازنشستگی,退休,выход на пенсию,pensiun,ریٹائرمنٹ
+,social learning,MULTIPLE,,,aprendizaje social,apprentissage social,aprendizagem social,تعليم اجتماعي,یادگیری اجتماعی,社會學習,социальное обучение,pembelajaran sosial,سماجی سیکھنے
+,sport event,MULTIPLE,,,evento deportivo,événement sportif,evento esportivo,حدث رياضي,رویداد ورزشی,體育賽事,Спортивное событие,acara olahraga,کھیل کی تقریب
+,study in the U.S.,MULTIPLE,,,estudiar en Estados Unidos,Études aux USA,estudar nos EUA,الدراسة في الولايات المتحدة,تحصیل در ایالات متحده,留学美国,Учеба в США,belajar di AS,امریکہ میں تعلیم حاصل کریں
+,travel to the U.S. ,MULTIPLE,,,viajar a Estados Unidos,Voyages aux États-Unis,viajar para os EUA,السفر إلى الولايات المتحدة,سفر به ایالات متحده,赴美旅行,Путешествие в США,bepergian ke AS,امریکہ آئیں
+,U.S. Government,MULTIPLE,,,Gobierno de Estados Unidos,Gouvernement américain,Governo dos EUA,الحكومة الأميركية,دولت ایالات متحده,美国政府,Правительство США,Pemerintah AS,امریکی حکومت
+,values,MULTIPLE,,,valores,valeurs,valores,القيم,ارزش های,值,значения,nilai-nilai,اقدار
+Arts & Culture,,,,Arts & Entertainment | Arts and Society,Arte y cultura,Arts et culture,Artes e Cultura,فنون وثقافة,هنر و فرهنگ,藝術與文化,Искусство и культура,Seni & Budaya,آرٹس اور ثقافت
+,arts,,Parent Term,,artes,arts,artes,الفنون,هنر,艺术,искусство,Seni,فنون
+,culture,,Parent Term,,cultura,Culture,cultura,حضاره,فرهنگ,文化,культура,budaya,ثقافت
+,ceremony,MULTIPLE,,,ceremonia,la cérémonie,cerimônia,مراسم,مراسم,儀式,церемония,upacara,تقریب
+,entertainment,MULTIPLE,,,entretenimiento,divertissement,entretenimento,وسائل الترفيه,سرگرمی,娛樂,развлекательная программа,hiburan,تفریح
+,people,MULTIPLE,,,gente,gens,pessoas,اشخاص,مردم,人,люди,orang-orang,لوگ
+,sport event,MULTIPLE,,,evento deportivo,événement sportif,evento esportivo,حدث رياضي,رویداد ورزشی,體育賽事,Спортивное событие,acara olahraga,کھیل کی تقریب
+,travel to the U.S. ,MULTIPLE,,,viajar a Estados Unidos,Voyages aux États-Unis,viajar para os EUA,السفر إلى الولايات المتحدة,سفر به ایالات متحده,赴美旅行,Путешествие в США,bepergian ke AS,امریکہ آئیں
+Democracy & Civil Society,,,,,Democracia y sociedad civil,Démocratie et société civile,Democracia e sociedade civil,الديمقراطية والمجتمع المدني,دموکراسی و جامعه مدنی,民主與公民社會,Демократия и гражданское общество,Demokrasi dan Masyarakat Sipil,جمہوریت اور سول سوسائٹی
+,anti-corruption,MULTIPLE,,,anti corrupcion,anti-corruption,anti-corrupção,مكافحة الفساد,ضد فساد,反腐敗,антикоррупционный,anti korupsi,انسداد فساد
+,civic leadership,,,,liderazgo cívico,leadership civique,liderança cívica,القيادة المدنية,رهبری مدنی,公民領導,гражданское лидерство,kepemimpinan sipil,شہری قیادت
+,civil society,,Parent Term,,sociedad civil,Société civile,sociedade civil,المجتمع المدني,جامعه مدنی,公民社会,Гражданское общество,masyarakat madani,سول سوسائٹی
+,civil unrest,MULTIPLE,,,disturbios civiles,troubles civils,agitação civil,اضطراب مدني,ناآرامی مدنی,內亂,гражданские беспорядки,kerusuhan sipil,سول بدامنی
+,communities,,,,comunidades,communautés,comunidades,مجتمعات,جوامع,社區,сообщества,komunitas,کمیونٹی
+,democracy,MULTIPLE,Parent Term,,DEMOCRACIA,Démocratie,democracia,الديمقراطية,دموکراسی,民主,Демократия,Demokrasi,جمہوریت
+,detainees,,,,detenidos,détenus,detidos,المعتقلين,بازداشت شدگان,被拘留者,задержанные,tahanan,قیدی
+,development,MULTIPLE,,,desarrollo,Développement,desenvolvimento,التنمية,توسعه,发展,Развитие,pembangunan,ترقی
+,diversity,MULTIPLE,,,diversidad,Diversité,diversidade,التنوع,گوناگونی,多样性,Разнообразие,keberagaman,تنوع
+,drug use,MULTIPLE,,,el consumo de drogas,l'usage de drogues,uso de drogas,تعاطي المخدرات,استفاده مواد مخدر,用藥,употребление наркотиков,penggunaan obat,منشیات کا استعمال
+,election,MULTIPLE,,,elección,élection,eleição,انتخاب,انتخابات,選舉,выборы,pemilihan,انتخاب
+,emergency incident,MULTIPLE,,,incidente de emergencia,incident d'urgence,incidente de emergência,حادث طارئ,حادثه اضطراری,緊急事件,аварийный инцидент,insiden darurat,ہنگامی واقعہ
+,emergency planning,MULTIPLE,,,planificación de emergencias,planification d'urgence,planejamento de emergência,تخطيط الطوارئ,برنامه ریزی اضطراری,應急計劃,планирование чрезвычайных ситуаций,perencanaan darurat,ہنگامی منصوبہ بندی
+,emergency response,MULTIPLE,,,respuesta de emergencia,réponse d'urgence,Resposta de emergência,رد طارئ,پاسخ اضطرار ی,應急響應,аварийного реагирования,respon darurat,ہنگامی ردعمل
+,family,,,,familia,famille,família,أسرة,خانواده,家庭,семья,keluarga,خاندان
+,foreign aid,,,,Ayuda exterior,Aide à l’étranger,Ajuda externa,مساعدات خارجية,کمک های خارجی,对外援助,Внешняя помощь,Bantuan Luar Negeri,غیر ملکی امداد
+,government policy,MULTIPLE,,,política gubernamental,politique gouvernementale,política do governo,سياسة الحكومة,سیاست دولت,政府政策,правительственная политика,Kebijakan pemerintah,حکومتی پالیسی
+,humankind,,,mankind,Humanidad,Humanité,Humanidade,البشرية,HUmankind,人類,человечество,HUmankind,HUmankind
+,international relations,MULTIPLE,,,Relaciones internacionales,Relations internationales,Relações internacionais,العلاقات الدولية,روابط بین المللی,国际关系,"Международные
+отношения",Hubungan Internasional,بین الاقوامی تعلقات
+,interreligious dialogue,MULTIPLE,,,diálogo interreligioso,dialogue interreligieux,diálogo inter-religioso,الحوار بين الاديان,گفتگوی مذهبی,宗教間對話,межрелигиозный диалог,dialog antaragama,مداخلت کی بات چیت
+,law enforcement,,,,cumplimiento de la ley,forces de l'ordre,aplicação da lei,تطبيق القانون,اجرای قانون,執法,правоохранительные органы,penegakan hukum,قانون نافذ کرنے والے
+,leadership,MULTIPLE,,,liderazgo,direction,Liderança,قيادة,رهبری,領導,руководство,kepemimpinan,قیادت
+,leadership & community action,MULTIPLE,,,Liderazgo y acción comunitaria,leadership et action communautaire,liderança e ação comunitária,القيادة والعمل المجتمعي,رهبری و اقدامات اجتماعی,領導力和社區行動,руководство и действия сообщества,kepemimpinan & aksi komunitas,قیادت اور کمیونٹی کی کارروائی
+,non-governmental organization (NGO),MULTIPLE,,,organización no gubernamental (ONG),organisation non gouvernementale (ONG),organização não governamental (ONG),منظمة غير حكومية (NGO),سازمان غیردولتی (NGO),非政府組織（NGO）,неправительственная организация (НПО),organisasi non-pemerintah (LSM),غیر سرکاری تنظیم (این جی او)
+,post-war reconstruction,MULTIPLE,,,reconstrucción de posguerra,reconstruction d'après-guerre,reconstrução pós-guerra,إعادة الإعمار بعد الحرب,بازسازی پس از جنگ,戰後重建,послевоенная реконструкция,rekonstruksi pasca perang,جنگ کے بعد تعمیر
+,prisoners,MULTIPLE,,,presos,les prisonniers,prisioneiros,السجناء,زندانیان,囚犯,заключенных,tahanan,قیدیوں
+,public management,,,,gestión pública,gestion publique,gestão pública,الإدارة العامة,مدیریت عمومی,公共管理,государственное управление,manajemen publik,عوامی انتظام
+,social condition,MULTIPLE,,,condición social,Condition sociale,Condição social,حالة اجتماعية,شرایط اجتماعی,社會狀況,социальное состояние,kondisi sosial,سماجی حالت
+,social problem,,,,problema social,problème social,Problema social,مشكلة اجتماعية,مشکل اجتماعی,社會問題,социальная проблема,masalah sosial,سماجی مسئلہ
+,state relations,MULTIPLE,,,relaciones estatales,relations d'état,relações estatais,علاقات الدولة,روابط دولت,國家關係,отношения государства,hubungan negara,ریاستی تعلقات
+,transparency,MULTIPLE,,,transparencia,transparence,transparência,الشفافية,شفافیت,透明度,прозрачность,Transparansi,شفافیت
+,women & girls,MULTIPLE,,,mujeres y niñas,Femmes et filles,mulheres e meninas,النساء والفتيات,زنان و دختران,妇女和女孩,Женщины и девочки,perempuan & anak perempuan,عورتیں اور لڑکیاں
+,women's issues,MULTIPLE,,,Problemas de mujeres,les problèmes des femmes,problemas femininos,قضايا المرأة,مسائل زنان,婦女的問題,проблемы женщин,masalah wanita,خواتین کے مسائل
+,women’s empowerment,MULTIPLE,,,potenciación de la mujer,autonomisation des femmes,empoderamento da mulher,تمكين النساء,توانمندسازی زنان,女性自主权,расширение прав и возможностей женщин,pemberdayaan wanita,خواتین کو بااختیار بنانا
 Economic Opportunity,,,,"Economic Security | Economic Prosperity | Business, Economy, & Finance | Entrepreneurship | 
 Economic Diplomacy | Economic Policy & Development | Economic Issues
-"
-,agriculture,MULTIPLE,,
-,business and entrepreneurship,,,
-,business planning,,,
-,business plans & operations,,,
-,economic opportunity,,Parent Term,Economy
-,economic sector,,,
-,employment,MULTIPLE,,
-,entrepreneurship,,,
-,exchange,MULTIPLE,,
-,funding,,,
-,international trade,,,
-,labor market,,,
-,labor relations,,,
-,market,,,
-,natural resources,MULTIPLE,,
-,personal & professional development,MULTIPLE,,
-,retirement,MULTIPLE,,
-,small family business,,,
-,social condition,MULTIPLE,,
-,social entrepreneurship,,,
-,startups,,,startup
-,unemployment,,,
-,unions,MULTIPLE,,
-Education,,,,
-,application information,,,
-,english learning,MULTIPLE,,
-,exchange,MULTIPLE,,
-,mathematics,MULTIPLE,,
-,mechanical engineering,MULTIPLE,,
-,personal & professional development,MULTIPLE,,
-,religious education,MULTIPLE,,
-,research,MULTIPLE,,
-,school,MULTIPLE,,
-,school,MULTIPLE,,
-,scientific institutions,MULTIPLE,,
-,social learning,MULTIPLE,,
-,social sciences,,,
-,study in the U.S.,MULTIPLE,,
-,teaching,,,
-Environment,,,,
-,agriculture,MULTIPLE,,
-,animal,,,
-,climate,,,
-,climate change,,,
-,conservation,,,
-,environmental politics,,,
-,environmental pollution,,,
-,natural resources,MULTIPLE,,
-,natural science,,,
-,nature,,,
-,oceans,,,
-,plant,,,
-,scientific institutions,MULTIPLE,,
-,scientific standards,MULTIPLE,,
-,weather forecast,,,
-,weather phenomena,,,
-,weather statistic,,,
-,weather warning,,,
-,wildlife,,,
-Geography,,,,Global
-,continents,,,
-,countries,,,
-,demographics,,,
-,geographical regions,,,
-,international relations,MULTIPLE,,
-Global Issues,,,,Global Security | Countering Violent Extremism | Peace & Security | International Relations
-,act of terror,MULTIPLE,,
-,armed conflict,MULTIPLE,,
-,civil unrest,MULTIPLE,,
-,countering violent extremism,MULTIPLE,,
-,coup d’etat,MULTIPLE,,
-,emergency incident,MULTIPLE,,
-,emergency planning,MULTIPLE,,
-,emergency response,,,
-,global issues,,Parent Term,
-,international relations,MULTIPLE,,
-,massacre,,,
-,peace process,MULTIPLE,,
-,post-war reconstruction,MULTIPLE,,
-,state relations,MULTIPLE,,
-Health,,,,
-,biomedical science,MULTIPLE,,
-,diseases,,,
-,drug use,MULTIPLE,,
-,health facility,,,
-,health organizations,,,
-,health treatment,,,
-,healthcare policy,,,
-,medical profession,,,
-,non-governmental organization (NGO),MULTIPLE,,
-,non-human diseases,,,
-,treatment,,,
-Human Rights,,,,
-,discrimination,,,
-,employment,MULTIPLE,,
-,fundamental rights,,,
-,human rights,,Parent Term,
-,LGBTI,,,LGBT | lesbian | gay | bisexual | transgender | intersex 
-,pride,,,
-,prisoners,MULTIPLE,,
-,rights,,,
-,social condition,MULTIPLE,,
-,unions,MULTIPLE,,
-,welfare,MULTIPLE,,
-,women & girls,MULTIPLE,,
-,women's issues,MULTIPLE,,
-,women’s empowerment,MULTIPLE,,
-Press & Journalism,,,,
-,mass media,,,
-,media & press,,,media | press
-Good Governance,,,,Politics | Governance | Democratic Governance
-,anti-corruption,MULTIPLE,,
-,coup d’etat,,,
-,democracy,MULTIPLE,,
-,election,MULTIPLE,,
-,governance,,,
-,government,,,
-,government policy,MULTIPLE,,
-,judiciary,,,
-,peace process,MULTIPLE,,
-,policy,,,
-,political crisis,,,
-,political dissent,,,
-,political process,,,
-,transparency,MULTIPLE,,
-,U.S. Government,MULTIPLE,,
-,welfare,MULTIPLE,,
-Religion & Values,,,,
-,interfaith,,,
-,interreligious dialogue,MULTIPLE,,
-,religious belief,,,
-,religious conflict,,,
-,religious education,MULTIPLE,,
-,religious event,,,
-,religious facilities,,,
-,religious institutions,,,
-,religious leader,,,
-,religious text,,,
-,values,MULTIPLE,Parent Term,
-Science & Technology,,,,
-,biomedical science,MULTIPLE,,
-,mathematics,MULTIPLE,,
-,mechanical engineering,MULTIPLE,,
-,research,MULTIPLE,,
-,scientific institutions,MULTIPLE,,
-,scientific standards,MULTIPLE,,
-,engineering,MULTIPLE,,
-,development,MULTIPLE,,
-Sports,,,,
-,ceremony,MULTIPLE,,
-,competition discipline,,,
-,disciplinary action in sport,,,
-,drug use in sport,,,
-,sport event,MULTIPLE,,
-,sport industry,,,
-,sport organization,,,
-,sport venue,,,
+",Oportunidades económicas,"Opportunités
+économiques",Oportunidade econômica,فرص اقتصادية,فرصت های اقتصادی,经济机会,"Экономические
+возможности",Peluang  Ekonomi,اقتصادی موقع
+,agriculture,MULTIPLE,,,agricultura,agriculture,agricultura,الزراعة,کشاورزی,農業,сельское хозяйство,pertanian,زراعت
+,business and entrepreneurship,,,,negocios y emprendimiento,affaires et entrepreneuriat,negócios e empreendedorismo,الأعمال وريادة الأعمال,کسب و کار و کارآفرینی,商業和創業,бизнес и предпринимательство,bisnis dan kewirausahaan,کاروبار اور کاروباری اداری
+,business planning,,,,planificación empresarial,Planning d'affaires,planejamento de negócios,تخطيط الأعمال,برنامه ریزی کسب و کار,商業計劃,планирование бизнеса,"perencanaan bisnis
+",کاروباری منصوبہ بندی
+,business plans & operations,,,,planes de negocios y operaciones,plans d'affaires et opérations,planos de negócios e operações,خطط العمل والعمليات,برنامه های تجاری و عملیات,業務計劃和運營,бизнес-планы и операции,encana & operasi bisnis,کاروباری منصوبہ بندی اور آپریشن
+,economic opportunity,,Parent Term,Economy,Oportunidades económicas,"Opportunités
+économiques",Oportunidade econômica,فرص اقتصادية,فرصت های اقتصادی,经济机会,"Экономические
+возможности",Peluang  Ekonomi,اقتصادی موقع
+,economic sector,,,,Sector económico,secteur économique,setor economico,القطاع الاقتصادي,بخش اقتصادی,經濟部門,экономический сектор,sektor ekonomi,اقتصادی شعبے
+,employment,MULTIPLE,,,empleo,emploi,emprego,توظيف,استخدام,僱用,занятость,pekerjaan,روزگار
+,entrepreneurship,,,,espíritu empresarial,Esprit d'entreprise,empreendedorismo,ريادة الاعمال,کارآفرینی,创业 ,предпринимательство,Kewirausahaan,کاروباری تنظیم کار
+,exchange,MULTIPLE,,,intercambiar,échange,troca,تبادل,تبادل,交換,обмен,bertukar,تبادلہ
+,funding,,,,Fondos,Financement,Financiamento,التمويل,منابع مالی,資金,финансирование,Pendanaan,فنڈ
+,international trade,,,,comercio internacional,Commerce international,comércio internacional,التجارة الدولية ,تجارت بین المللی,国际贸易,международная торговля,perdagangan internasional,بین الاقوامی تجارت
+,labor market,,,,mercado de trabajo,marché du travail,mercado de trabalho,سوق العمل,بازار کار,勞動力市場,рынок труда,pasar tenaga kerja,مزدوروں کی منڈی
+,labor relations,,,,relaciones laborales,les relations de travail,relações de trabalho,علاقات العمل,روابط کارگری,勞動關係,трудовые отношения,hubungan kerja,مزدور تعلقات
+,market,,,,mercado,marché,mercado,سوق,بازار,市場,рынок,pasar,مارکیٹ
+,natural resources,MULTIPLE,,,recursos naturales,ressources naturelles,recursos naturais,الموارد الطبيعية,منابع طبیعی,自然資源,природные ресурсы,sumber daya alam,قدرتی وسائل
+,personal & professional development,MULTIPLE,,,desarrollo personal y profesional,développement personnel et professionnel,desenvolvimento pessoal e profissional,التطوير الشخصي والمهني,توسعه شخصی و حرفه ای,個人和職業發展,личное и профессиональное развитие,pengembangan pribadi & profesional,ذاتی اور پیشہ ورانہ ترقی
+,retirement,MULTIPLE,,,Jubilación,retraite,aposentadoria,تقاعد,بازنشستگی,退休,выход на пенсию,pensiun,ریٹائرمنٹ
+,small family business,,,,pequeña empresa familiar,petite entreprise familiale,pequena empresa familiar,الشركات العائلية الصغيرة,کسب و کار خانوادگی کوچک,小型家族企業,небольшой семейный бизнес,bisnis keluarga kecil,چھوٹے خاندان کے کاروبار
+,social condition,MULTIPLE,,,condición social,Condition sociale,Condição social,حالة اجتماعية,شرایط اجتماعی,社會狀況,социальное состояние,kondisi sosial,سماجی حالت
+,social entrepreneurship,,,,el emprendimiento social,l'entrepreneuriat social,empreendedorismo Social,المشاريع الاجتماعية,کارآفرینی اجتماعی,社會創業,социальное предпринимательство,kewirausahaan sosial,سماجی کاروباری
+,startups,,,startup | start-up,puesta en marcha,démarrer,arranque,تبدأ,شروع کن,啟動,запускать,memulai,شروع کرو
+,unemployment,,,,desempleo,chômage,desemprego,بطالة,بیکاری,失業,безработица,pengangguran,بے روزگار
+,unions,MULTIPLE,,,sindicatos,syndicats,uniões,النقابات,اتحادیه ها,工會,союзы,serikat pekerja,یونین
+Education,,,,,educación,Éducation,educação,التعليم,آموزش,教育,Образование,Pendidikan,تعلیم
+,application information,,,,información de la aplicación,informations d'application,informação da aplicação,معلومات التطبيق,اطلاعات برنامه,應用信息,информация о приложении,informasi aplikasi,درخواست کی معلومات
+,english learning,MULTIPLE,,,aprendizaje del idioma inglés,Anglais langue étrangère,aprendizagem de Inglês,تعلم اللغة الإنجليزية,یادگیری زبان انگلیسی,英语学习,Изучение английского языка,pembelajaran bahasa Inggris,انگریزی سیکھنا
+,exchange,MULTIPLE,,,intercambiar,échange,troca,تبادل,تبادل,交換,обмен,bertukar,تبادلہ
+,mathematics,MULTIPLE,,,matemáticas,mathématiques,matemática,الرياضيات,ریاضیات,數學,математика,matematika,ریاضی
+,mechanical engineering,MULTIPLE,,,Ingeniería mecánica,ingénierie mécanique,Engenharia Mecânica,مهندس ميكانيكى,مهندسی مکانیک,機械工業,машиностроение,teknik Mesin,میکینکل انجینئرنگ
+,personal & professional development,MULTIPLE,,,desarrollo personal y profesional,développement personnel et professionnel,desenvolvimento pessoal e profissional,التطوير الشخصي والمهني,توسعه شخصی و حرفه ای,個人和職業發展,личное и профессиональное развитие,pengembangan pribadi & profesional,ذاتی اور پیشہ ورانہ ترقی
+,religious education,MULTIPLE,,,educación religiosa,éducation religieuse,Educação religiosa,التعليم الديني,مطالعات دینی و اعتقادی,宗教教育,религиозное образование,pendidikan agama,دینی تعلیم
+,research,MULTIPLE,,,investigación,recherche,pesquisa,ابحاث,پژوهش,研究,исследование,penelitian,تحقیق
+,school,MULTIPLE,,,colegio,école,escola,مدرسة,مدرسه,學校,школа,sekolah,اسکول
+,school,MULTIPLE,,,colegio,école,escola,مدرسة,مدرسه,學校,школа,sekolah,اسکول
+,scientific institutions,MULTIPLE,,,instituciones científicas,institutions scientifiques,instituições científicas,المؤسسات العلمية,موسسات علمی,科學機構,научных учреждений,institusi ilmiah,سائنسی اداروں
+,social learning,MULTIPLE,,,aprendizaje social,apprentissage social,aprendizagem social,تعليم اجتماعي,یادگیری اجتماعی,社會學習,социальное обучение,pembelajaran sosial,سماجی سیکھنے
+,social sciences,,,,Ciencias Sociales,Sciences sociales,Ciências Sociais,العلوم الاجتماعية,علوم اجتماعی,社會科學,социальные науки,ilmu Sosial,سماجی علوم
+,study in the U.S.,MULTIPLE,,,estudiar en Estados Unidos,Études aux USA,estudar nos EUA,الدراسة في الولايات المتحدة,تحصیل در ایالات متحده,留学美国,Учеба в США,belajar di AS,امریکہ میں تعلیم حاصل کریں
+,teaching,,,,enseñando,enseignement,ensino,تعليم,درس دادن,教學,обучение,pengajaran,پڑھانا
+Environment,,,,,medioambiente,Environnement,meio ambiente,البيئة,محیط زیست,环境,Окружающая среда,lingkungan hidup,ماحول
+,agriculture,MULTIPLE,,,agricultura,agriculture,agricultura,الزراعة,کشاورزی,農業,сельское хозяйство,pertanian,زراعت
+,animal,,,,animal,animal,animal,حيوان,حیوانات,動物,животное,hewan,جانور
+,climate,,,,clima,climat,clima,مناخ,"آب و هوا
+",氣候,климат,iklim,آب و ہوا
+,climate change,,,,cambio climático,Changement climatique,mudanças climáticas,تغير المناخ,تغییرات آب و هوا,气候变化,изменение климата,perubahan iklim,آب و ہوا میں تبدیلی
+,conservation,,,,conservación,Conservation,conservação,المحميات,محافظت از محیط زیست,自然保护,охрана окружающей среды,konservasi/pelestarian,تحفظ
+,environmental politics,,,,política ambiental,politique environnementale,política ambiental,السياسة البيئية,سیاست زیست محیطی,環境政治,экологическая политика,politik lingkungan,ماحولیاتی سیاست
+,environmental pollution,,,,contaminación ambiental,pollution environnementale,poluição ambiental,التلوث البيئي,آلودگی محیطی,環境污染,загрязнение окружающей среды,pencemaran lingkungan,ماحولیاتی آلودگی
+,natural resources,MULTIPLE,,,recursos naturales,ressources naturelles,recursos naturais,الموارد الطبيعية,منابع طبیعی,自然資源,природные ресурсы,sumber daya alam,قدرتی وسائل
+,natural science,,,,Ciencias Naturales,sciences naturelles,Ciência natural,علم الطبيعة,علوم طبیعی,自然科學,естественные науки,ilmu pengetahuan Alam,قدرتی سائنس
+,nature,,,,naturaleza,la nature,natureza,طبيعة,طبیعت,性質,природа,alam,فطرت
+,oceans,,,,océanos,océans,oceanos,المحيطات,اقیانوس,海洋,океаны,Lautan,سمندر
+,plant,,,,planta,plante,plantar,نبات,گیاه,廠,растение,menanam,پلانٹ
+,scientific institutions,MULTIPLE,,,instituciones científicas,institutions scientifiques,instituições científicas,المؤسسات العلمية,موسسات علمی,科學機構,научных учреждений,institusi ilmiah,سائنسی اداروں
+,scientific standards,MULTIPLE,,,estándares científicos,normes scientifiques,padrões científicos,المعايير العلمية,استانداردهای علمی,科學標準,научные стандарты,standar ilmiah,سائنسی معیار
+,weather forecast,,,,pronóstico del tiempo,prévisions météorologiques,previsão do tempo,النشرة الجوية,پیش بینی آب و هوا,天氣預報,прогноз погоды,Prakiraan Cuaca,موسم کا حال
+,weather phenomena,,,,fenómenos meteorológicos,phénomènes météorologiques,fenômenos climáticos,ظواهر الطقس,پدیده آب و هوا,天氣現象,явления погоды,fenomena cuaca,موسم کے رجحان
+,weather statistic,,,,estadística del tiempo,statistique météorologique,estatística do tempo,إحصائيات الطقس,آمار آب و هوا,天氣統計,статистика погоды,statistik cuaca,موسم کی حیثیت
+,weather warning,,,,advertencia del clima,avertissement de temps,aviso de tempo,تحذير الطقس,هشدار هوا,天氣警告,предупреждение о погоде,peringatan cuaca,موسم انتباہ
+,wildlife,,,,Vida silvestre,Faune et flore,Vida selvagem,الحياة البرية,حیات وحش,野生生物,Живая природа,Margasatwa,جَنگَلی حَيات
+Geography,,,,Global,Geografía,Géographie,Geografia,جغرافية,جغرافیا,جغرافیا,география,Geografi,جغرافیہ
+,continents,,,,continentes,continents,continentes,القارات,قاره ها,大陸,континенты,benua,براعظم
+,countries,,,,países,des pays,paises,بلدان,کشورها,國家,страны,negara-negara,ممالک
+,demographics,,,,datos demográficos,démographie,demografia,التركيبة السكانية,جمعیت شناسی,人口統計學,демографические,demografi,ڈیموگرافکس
+,geographical regions,,,,regiones geográficas,régions géographiques,regiões geográficas,المناطق الجغرافية,مناطق جغرافیایی,地理區域,географических регионах,wilayah geografis,جغرافیای علاقوں
+,international relations,MULTIPLE,,,Relaciones internacionales,Relations internationales,Relações internacionais,العلاقات الدولية,روابط بین المللی,国际关系,"Международные
+отношения",Hubungan Internasional,بین الاقوامی تعلقات
+Global Issues,,,,Global Security | Countering Violent Extremism | Peace & Security | International Relations,Asuntos mundiales,Questions mondiales,Questões globais,قضايا عالمية,مسائل جهانی,全球事务,Глобальные вопросы,Isu Global,عالمگیر مسائل
+,act of terror,MULTIPLE,,,acto de terror,acte de terreur,ato de terror,فعل من الارهاب,اقدام تروریستی,恐怖行為,акт ужаса,tindakan teror,دہشت گردی کا کام
+,armed conflict,MULTIPLE,,,conflicto armado,un conflit armé,conflito armado,الصراع المسلح,درگیری های مسلحانه,武裝衝突,вооруженный конфликт,konflik bersenjata,مسلح تصادم
+,civil unrest,MULTIPLE,,,disturbios civiles,troubles civils,agitação civil,اضطراب مدني,ناآرامی مدنی,內亂,гражданские беспорядки,kerusuhan sipil,سول بدامنی
+,countering violent extremism,MULTIPLE,,,"Contrarrestar el extremismo
+violento","Contrer l’extrémisme
+violent","Combate ao extremismo
+violento",مكافحة التطرّف العنيف,مقابله با افراط گرایی خشونت آمیز,抗击暴力极端主义,"Противодействие
+насильственному 
+экстремизму",Melawan kekerasan ekstremisme,پرتشدد انتہا پسندی کا مقابلہ کرنا
+,coup d’etat,MULTIPLE,,,golpe de Estado,coup d'État,golpe de Estado,قاعدة شاذة,کودتا,政變,государственный переворот,kudeta,بغاوت
+,emergency incident,MULTIPLE,,,incidente de emergencia,incident d'urgence,incidente de emergência,حادث طارئ,حادثه اضطراری,緊急事件,аварийный инцидент,insiden darurat,ہنگامی واقعہ
+,emergency planning,MULTIPLE,,,planificación de emergencias,planification d'urgence,planejamento de emergência,تخطيط الطوارئ,برنامه ریزی اضطراری,應急計劃,планирование чрезвычайных ситуаций,perencanaan darurat,ہنگامی منصوبہ بندی
+,emergency response,,,,respuesta de emergencia,réponse d'urgence,Resposta de emergência,رد طارئ,پاسخ اضطرار ی,應急響應,аварийного реагирования,respon darurat,ہنگامی ردعمل
+,global issues,,Parent Term,,Asuntos mundiales,Questions mondiales,Questões globais,قضايا عالمية,مسائل جهانی,全球事务,Глобальные вопросы,Isu Global,عالمگیر مسائل
+,international relations,MULTIPLE,,,Relaciones internacionales,Relations internationales,Relações internacionais,العلاقات الدولية,روابط بین المللی,国际关系,"Международные
+отношения",Hubungan Internasional,بین الاقوامی تعلقات
+,massacre,,,,masacre,massacre,massacre,مذبحة,قتل عام,屠殺,бойня,pembantaian,قتل عام
+,peace process,MULTIPLE,,,proceso de paz,procédé de paix,processo de paz,عملية السلام,روند صلح,和平進程,мирный процесс,proses perdamaian,امن عمل
+,post-war reconstruction,MULTIPLE,,,reconstrucción de posguerra,reconstruction d'après-guerre,reconstrução pós-guerra,إعادة الإعمار بعد الحرب,بازسازی پس از جنگ,戰後重建,послевоенная реконструкция,rekonstruksi pasca perang,جنگ کے بعد تعمیر
+,state relations,MULTIPLE,,,relaciones estatales,relations d'état,relações estatais,علاقات الدولة,روابط دولت,國家關係,отношения государства,hubungan negara,ریاستی تعلقات
+Health,,,,,salud,Santé,saúde,الصحة,بهداشت,健康,Здоровье,kesehatan,صحت
+,biomedical science,MULTIPLE,,,ciencia Biomedica,science biomédicale,Ciência biomédica,علم الطب الحيوي,علم پزشکی,生物醫學科學,биомедицинская наука,ilmu biomedis,حیاتیاتی سائنس
+,diseases,,,,enfermedades,maladies,doenças,الأمراض,بیماری ها,疾病,болезни,penyakit,بیماریوں
+,drug use,MULTIPLE,,,uso de drogas,usage de drogues,uso de drogas,تعاطي المخدرات,用藥,用藥,употребление наркотиков,penggunaan narkoba,منشیات کا استعمال
+,health facility,,,,facilidad de salud,établissement de santé,estabelecimento de saúde,مرفق صحي,مرکز بهداشت,衛生設施,медицинское учреждение,fasilitas kesehatan,صحت کی سہولت
+,health organizations,,,,organizaciones de salud,organisations de santé,organizações de saúde,المنظمات الصحية,سازمان های بهداشتی,衛生組織,организации здравоохранения,organisasi kesehatan,صحت کی تنظیمیں
+,health treatment,,,,tratamiento de salud,traitement de santé,tratamento de saúde,العلاج الصحي,درمان درمانی,健康治療,лечение,perawatan kesehatan,صحت کا علاج
+,healthcare policy,,,,política de salud,politique de santé,política de saúde,سياسة الرعاية الصحية,سیاست های بهداشتی,保健政策,политика здравоохранения,kebijakan perawatan kesehatan,صحت کی دیکھ بھال کی پالیسی
+,medical profession,,,,profesión médica,profession médicale,profissão médica,مهنة طبية,حرفه پزشکی,醫學界,Медицинская профессия,profesi medis,طبی پیشہ
+,non-governmental organization (NGO),MULTIPLE,,,organización no gubernamental (ONG),organisation non gouvernementale (ONG),organização não governamental (ONG),منظمة غير حكومية (NGO),سازمان غیردولتی (NGO),非政府組織（NGO）,неправительственная организация (НПО),organisasi non-pemerintah (LSM),غیر سرکاری تنظیم (این جی او)
+,non-human diseases,,,,enfermedades no humanas,maladies non-humaines,doenças não humanas,أمراض غير بشرية,بیماری های غیر انسانی,非人類疾病,нечеловеческие заболевания,penyakit non-manusia,غیر انسانی بیماریوں
+,treatment,,,,tratamiento,traitement,tratamento,علاج او معاملة,رفتار,治療,лечение,pengobatan,علاج
+Human Rights,,,,,derechos humanos,Droits de l’homme,direitos humanos,حقوق الإنسان,حقوق بشر,人权,Права человека,Hak asasi manusia (HAM),انسانی حقوق
+,discrimination,,,,discriminación,discrimination,discriminação,تمييز,تبعیض,區別,дискриминация,diskriminasi,امتیازی سلوک
+,employment,MULTIPLE,,,empleo,emploi,emprego,توظيف,استخدام,僱用,занятость,pekerjaan,روزگار
+,fundamental rights,,,,derechos fundamentales,droits fondamentaux,direitos fundamentais,الحقوق الأساسية,حقوق بنیادی,基本權利,основные права,hak dasar,بنیادی حقوق
+,human rights,,Parent Term,,derechos humanos,Droits de l’homme,direitos humanos,حقوق الإنسان,حقوق بشر,人权,Права человека,Hak asasi manusia (HAM),انسانی حقوق
+,LGBTI,,,LGBT | lesbian | gay | bisexual | transgender | intersex ,LGBTI,LGBTI,LGBT,المثليون ومزدوجو الميل الجنسي ومغايرو الهوية الجنسانية,دگرباشان,LGBTI,ЛГБТИ,LGBTI,ایل جی بی ٹی آئی
+,pride,,,,فخر,fierté,orgulho,فخر,غرور,自豪,гордость,kebanggaan,فخر
+,prisoners,MULTIPLE,,,السجناء,les prisonniers,prisioneiros,السجناء,زندانیان,囚犯,заключенных,tahanan,قیدیوں
+,rights,,,,حقوق,droits,direitos,حقوق,حقوق,權利,права,hak,حقوق
+,social condition,MULTIPLE,,,حالة اجتماعية,Condition sociale,Condição social,حالة اجتماعية,شرایط اجتماعی,社會狀況,социальное состояние,kondisi sosial,سماجی حالت
+,unions,MULTIPLE,,,النقابات,syndicats,uniões,النقابات,اتحادیه ها,工會,союзы,serikat pekerja,یونین
+,welfare,MULTIPLE,,,خير,aide sociale,bem-estar,خير,رفاه,福利,благосостояние,kesejahteraan,فلاح و بہبود
+,women & girls,MULTIPLE,,,mujeres y niñas,Femmes et filles,mulheres e meninas,النساء والفتيات,زنان و دختران,妇女和女孩,Женщины и девочки,perempuan & anak perempuan,عورتیں اور لڑکیاں
+,women's issues,MULTIPLE,,,Problemas de mujeres,les problèmes des femmes,problemas femininos,قضايا المرأة,مسائل زنان,婦女的問題,проблемы женщин,masalah wanita,خواتین کے مسائل
+,women’s empowerment,MULTIPLE,,,potenciación de la mujer,autonomisation des femmes,empoderamento da mulher,تمكين النساء,توانمندسازی زنان,女性自主权,расширение прав и возможностей женщин,pemberdayaan wanita,خواتین کو بااختیار بنانا
+Press & Journalism,,,,,Prensa y periodismo,Presse et journalisme,Imprensa e Jornalismo,الصحافة والصحافة,مطبوعات و روزنامه نگاری,新聞與新聞,Пресса и журналистика,Tekan & Jurnalisme,پریس اور صحافت
+,mass media,,,,medios de comunicación,médias de masse,mídia de massa,وسائل الإعلام الجماهيرية,رسانه های جمعی,媒體,СМИ,media massa,ذرائع ابلاغ
+,media & press,,,media | press,medios y prensa,médias et presse,mídia e imprensa,وسائل الاعلام والصحافة,رسانه ها و مطبوعات,媒體和媒體,СМИ и прессы,media & tekan,میڈیا اور پریس
+Good Governance,,,,Politics | Governance | Democratic Governance,buen gobierno,Gouvernance,boa governança,الحكم الرشيد,حکومت,良好治理,Эффективное управление,tata kelola pemerintahan yang baik,اچھی حکمرانی
+,anti-corruption,MULTIPLE,,,anti corrupcion,anti-corruption,anti-corrupção,مكافحة الفساد,ضد فساد,反腐敗,антикоррупционный,anti korupsi,انسداد فساد
+,coup d’etat,,,,golpe de Estado,coup d'État,golpe de Estado,قاعدة شاذة,کودتا,政變,государственный переворот,kudeta,بغاوت
+,democracy,MULTIPLE,,,DEMOCRACIA,Démocratie,democracia,الديمقراطية,دموکراسی,民主,Демократия,Demokrasi,جمہوریت
+,election,MULTIPLE,,,elección,élection,eleição,انتخاب,انتخابات,選舉,выборы,pemilihan,انتخاب
+,governance,,,,gobierno,Gouvernance,governança,الحكم,حکومت داری خوب ,治理,управление,pemerintahan,گورننس
+,government,,,,gobierno,gouvernement,governo,الحكومي,دولت,政府,правительство,pemerintah,حکومت
+,government policy,MULTIPLE,,,política gubernamental,politique gouvernementale,política do governo,سياسة الحكومة,سیاست دولت,政府政策,правительственная политика,Kebijakan pemerintah,حکومتی پالیسی
+,judiciary,,,,judicial,judiciaire,Judiciário,السلطة القضائية,قوه قضاییه,司法,судебная система,pengadilan,عدلیہ
+,peace process,MULTIPLE,,,proceso de paz,procédé de paix,processo de paz,عملية السلام,روند صلح,和平進程,мирный процесс,proses perdamaian,امن عمل
+,policy,,,,política,politique,política,سياسات,سیاست,政策,политика,kebijakan,پالیسی
+,political crisis,,,,Crisis política,crise politique,crise política,الأزمة السياسية,بحران سیاسی,政治危機,политический кризис,krisis politik,سیاسی بحران
+,political dissent,,,,disidencia política,dissidence politique,dissidência política,المعارضة السياسية,مخالفت سیاسی,政治異議,политическое несогласие,perbedaan pendapat politik,سیاسی اختلافات
+,political process,,,,proceso político,processus politique,processo político,العملية السياسية,فرایند سیاسی,政治過程,политический процесс,proses politik,سیاسی عمل
+,transparency,MULTIPLE,,,transparencia,transparence,transparência,الشفافية,شفافیت,透明度,прозрачность,Transparansi,شفافیت
+,U.S. Government,MULTIPLE,,,Gobierno de Estados Unidos,Gouvernement américain,Governo dos EUA,الحكومة الأميركية,دولت ایالات متحده,美国政府,Правительство США,Pemerintah AS,امریکی حکومت
+,welfare,MULTIPLE,,,bienestar,aide sociale,bem-estar,خير,رفاه,福利,благосостояние,kesejahteraan,فلاح و بہبود
+Religion & Values,,,,,Religión y valores,Religion et valeurs,Religião e Valores,الدين والقيم,دین و ارزش ها,宗教與價值觀,Религия и ценности,Agama & Nilai,مذہب اور اقدار
+,interfaith,,,,interreligioso,interconfessionnel,interfé,الأديان,مذهبی,信仰,межконфессиональный,antaragama,انٹرفی
+,interreligious dialogue,MULTIPLE,,,diálogo interreligioso,dialogue interreligieux,diálogo inter-religioso,الحوار بين الاديان,گفتگوی مذهبی,宗教間對話,межрелигиозный диалог,dialog antaragama,مداخلت کی بات چیت
+,religious belief,,,,creencia religiosa,croyance religieuse,crença religiosa,معتقد ديني,اعتقاد مذهبی,宗教信仰,религиозное верование,keyakinan agama,مذہبی عقیدہ
+,religious conflict,,,,conflicto religioso,conflit religieux,conflito religioso,الصراع الديني,اختلافات مذهبی,宗教衝突,религиозный конфликт,konflik agama,مذہبی تنازعہ
+,religious education,MULTIPLE,,,educación religiosa,éducation religieuse,Educação religiosa,التعليم الديني,مطالعات دینی و اعتقادی,宗教教育,религиозное образование,pendidikan agama,دینی تعلیم
+,religious event,,,,evento religioso,événement religieux,evento religioso,حدث ديني,رویداد مذهبی,宗教事件,религиозное событие,acara keagamaan,مذہبی تقریب
+,religious facilities,,,,instalaciones religiosas,installations religieuses,instalações religiosas,المرافق الدينية,امکانات مذهبی,宗教設施,религиозные объекты,fasilitas keagamaan,مذہبی سہولیات
+,religious institutions,,,,instituciones religiosas,institutions religieuses,instituições religiosas,المؤسسات الدينية,موسسات مذهبی,宗教機構,религиозные учреждения,institusi agama,مذہبی اداروں
+,religious leader,,,,líder religioso,leader réligieux,líder religioso,قائد ديني,رهبر مذهبی,宗教領袖,религиозный лидер,pemimpin religius,مذہبی رہنما
+,religious text,,,,texto religioso,texte religieux,texto religioso,النص الديني,متن مذهبی,宗教文本,религиозный текст,teks agama,مذہبی متن
+,values,MULTIPLE,Parent Term,,valores,valeurs,valores,القيم,ارزش های,值,значения,nilai-nilai,اقدار
+Science & Technology,,,,,ciencia y tecnología,Sciences & technologie,ciência & tecnologia,العلوم والتكنولوجيا,علم و فناوری,科学技术,Наука и технологии,IPTEK,سائنس اور ٹیکنالوجی
+,biomedical science,MULTIPLE,,,ciencia Biomedica,science biomédicale,Ciência biomédica,علم الطب الحيوي,علم پزشکی,生物醫學科學,биомедицинская наука,ilmu biomedis,حیاتیاتی سائنس
+,mathematics,MULTIPLE,,,matemáticas,mathématiques,matemática,الرياضيات,ریاضیات,數學,математика,matematika,ریاضی
+,mechanical engineering,MULTIPLE,,,Ingeniería mecánica,ingénierie mécanique,Engenharia Mecânica,مهندس ميكانيكى,مهندسی مکانیک,機械工業,машиностроение,teknik Mesin,میکینکل انجینئرنگ
+,research,MULTIPLE,,,investigación,recherche,pesquisa,ابحاث,پژوهش,研究,исследование,penelitian,تحقیق
+,scientific institutions,MULTIPLE,,,instituciones científicas,institutions scientifiques,instituições científicas,المؤسسات العلمية,موسسات علمی,科學機構,научных учреждений,institusi ilmiah,سائنسی اداروں
+,scientific standards,MULTIPLE,,,estándares científicos,normes scientifiques,padrões científicos,المعايير العلمية,استانداردهای علمی,科學標準,научные стандарты,standar ilmiah,سائنسی معیار
+,engineering,MULTIPLE,,,Ingenieria,ingénierie,Engenharia,هندسة,مهندسی,工程,инжиниринг,teknik,انجینئرنگ
+,development,MULTIPLE,,,desarrollo,Développement,desenvolvimento,التنمية,توسعه,发展,Развитие,pembangunan,ترقی
+Sports,,,,,Des sports,Des sports,Esportes,رياضات,ورزش ها,體育,Olahraga,Olahraga,کھیل
+,ceremony,MULTIPLE,,,ceremonia,la cérémonie,cerimônia,مراسم,مراسم,儀式,церемония,upacara,تقریب
+,competition discipline,,,,disciplina de competencia,discipline de la compétition,disciplina de competição,الانضباط المنافسة,نظم رقابت,競爭紀律,дисциплина соревнований,disiplin kompetisi,مقابلہ کی نظم و ضبط
+,disciplinary action in sport,,,,acción disciplinaria en el deporte,action disciplinaire dans le sport,ação disciplinar no esporte,العمل التأديبي في الرياضة,اقدام انضباطی در ورزش,紀律處分在體育運動,дисциплинарные меры в спорте,tindakan disipliner dalam olahraga,کھیل میں نظم و ضبط
+,drug use in sport,,,,uso de drogas en el deporte,l'usage de drogues dans le sport,uso de drogas no esporte,تعاطي المخدرات في الرياضة,مصرف مواد مخدر در ورزش,吸毒在運動中使用,употребление наркотиков в спорте,penggunaan narkoba dalam olahraga,کھیل میں منشیات کا استعمال
+,sport event,MULTIPLE,,,evento deportivo,événement sportif,evento esportivo,حدث رياضي,رویداد ورزشی,體育賽事,Спортивное событие,acara olahraga,کھیل کی تقریب
+,sport industry,,,,industria del deporte,industrie du sport,indústria esportiva,صناعة الرياضة,صنعت ورزش,體育產業,спортивная индустрия,industri olahraga,کھیل کی صنعت
+,sport organization,,,,organización deportiva,organisation sportive,organização esportiva,منظمة رياضية,سازمان های ورزشی,體育組織,спортивная организация,organisasi olahraga,کھیل تنظیم
+,sport venue,,,,complejo deportivo,complexe sportif,Local de esporte,مكان الرياضة,محل برگزاری مسابقات ورزشی,運動場地,спортивное место,tempat olahraga,کھیل کا مقام


### PR DESCRIPTION
Added functionality for populating the language property using a Translations column.
The column is a ' | ' delineated list of locale:translation pairs.
Moved to a column based translation import instead of a single column.
Updated the taxonomy csv in the imports dir.