### PR TITLE
CDP-623: Implement PUT controller for post updates

### DIFF
--- a/src/api/resources/course/model.js
+++ b/src/api/resources/course/model.js
@@ -3,17 +3,18 @@ import Ajv from 'ajv/lib/ajv';
 import courseSchema from '../../modules/schema/course';
 
 /**
- * Video Content Model helps in managing assets within JSON.
+ * Course Content Model helps in managing assets within JSON.
  */
 class Course extends AbstractModel {
   constructor( index = 'courses', type = 'course' ) {
     super( index, type );
-
-    // compile only once
-    this.compileSchema();
   }
 
-  static validateSchema( body ) {
+  static validateSchema( body, useDefaults = true ) {
+    if ( !Course.validate ) {
+      // compile only once
+      Course.compileSchema( useDefaults );
+    }
     const valid = Course.validate( body );
     return {
       valid,
@@ -22,11 +23,11 @@ class Course extends AbstractModel {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  compileSchema() {
+  static compileSchema( useDefaults = true ) {
     // 'useDefaults' adds a default value during validation if it is listed
     // 'removeAdditional' removes any properties during validation that are not in the schema
     // 'coerceTypes' will coerce to appropriate type.  using to coerce string number to number
-    const ajv = new Ajv( { useDefaults: true, removeAdditional: 'all', coerceTypes: true } );
+    const ajv = new Ajv( { useDefaults, removeAdditional: 'all', coerceTypes: true } );
     Course.validate = ajv.compile( courseSchema );
   }
 

--- a/src/api/resources/course/routes.js
+++ b/src/api/resources/course/routes.js
@@ -19,7 +19,7 @@ router
   .route( '/' )
   .post(
     validate( CourseModel ),
-    asyncResponse,
+    asyncResponse(),
     transferCtrl( CourseModel ),
     tagCategories,
     synonymCategories,
@@ -32,7 +32,7 @@ router
   .route( '/:uuid' )
   .put(
     validate( CourseModel ),
-    asyncResponse,
+    asyncResponse(),
     transferCtrl( CourseModel ),
     tagCategories,
     synonymCategories,

--- a/src/api/resources/post/controller.js
+++ b/src/api/resources/post/controller.js
@@ -1,7 +1,23 @@
-import { generateControllers } from '../../modules/controllers/generateResource';
+import {
+  generateControllers,
+  setRequestDocWithRetry,
+  setRequestDoc
+} from '../../modules/controllers/generateResource';
 import PostModel from './model';
 
-export default generateControllers( new PostModel() );
+const model = new PostModel();
+
+const setRequestDocBypass = ( req, res, next, uuid ) => {
+  if ( req.method === 'PUT' ) return next(); // bypass for PUT on post type route
+  return setRequestDoc( model )( req, res, next, uuid );
+};
+
+const overrides = {
+  setRequestDoc: setRequestDocBypass,
+  setRequestDocWithRetry: setRequestDocWithRetry( model )
+};
+
+export default generateControllers( model, overrides );
 
 /*
   NOTE: Generic controller methods can be overidden:

--- a/src/api/resources/post/model.js
+++ b/src/api/resources/post/model.js
@@ -8,12 +8,13 @@ import postSchema from '../../modules/schema/post';
 class Post extends AbstractModel {
   constructor( index = 'posts', type = 'post' ) {
     super( index, type );
-
-    // compile only once
-    this.compileSchema();
   }
 
-  static validateSchema( body ) {
+  static validateSchema( body, useDefaults = true ) {
+    if ( !Post.validate ) {
+      // compile only once
+      Post.compileSchema( useDefaults );
+    }
     const valid = Post.validate( body );
     return {
       valid,
@@ -22,11 +23,11 @@ class Post extends AbstractModel {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  compileSchema() {
+  static compileSchema( useDefaults = true ) {
     // 'useDefaults' adds a default value during validation if it is listed
     // 'removeAdditional' removes any properties during validation that are not in the schema
     // 'coerceTypes' will coerce to appropriate type.  using to coerce string number to number
-    const ajv = new Ajv( { useDefaults: true, removeAdditional: 'all', coerceTypes: true } );
+    const ajv = new Ajv( { useDefaults, removeAdditional: 'all', coerceTypes: true } );
     Post.validate = ajv.compile( postSchema );
   }
 

--- a/src/api/resources/post/routes.js
+++ b/src/api/resources/post/routes.js
@@ -19,7 +19,7 @@ router
   .route( '/' )
   .post(
     validate( PostModel ),
-    asyncResponse,
+    asyncResponse(),
     transferCtrl( PostModel ),
     tagCategories,
     synonymCategories,
@@ -31,12 +31,9 @@ router
 router
   .route( '/:uuid' )
   .put(
-    validate( PostModel ),
-    asyncResponse,
-    transferCtrl( PostModel ),
-    tagCategories,
-    synonymCategories,
-    translateCategories( PostModel ),
+    validate( PostModel, false ),
+    asyncResponse( false ),
+    controller.setRequestDocWithRetry,
     controller.updateDocumentById
   )
   .get( controller.getDocumentById )

--- a/src/api/resources/video/model.js
+++ b/src/api/resources/video/model.js
@@ -8,12 +8,13 @@ import videoSchema from '../../modules/schema/video';
 class Video extends AbstractModel {
   constructor( index = 'videos', type = 'video' ) {
     super( index, type );
-
-    // compile only once
-    this.compileSchema();
   }
 
-  static validateSchema( body ) {
+  static validateSchema( body, useDefaults = true ) {
+    if ( !Video.validate ) {
+      // compile only once
+      Video.compileSchema( useDefaults );
+    }
     const valid = Video.validate( body );
     return {
       valid,
@@ -22,11 +23,11 @@ class Video extends AbstractModel {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  compileSchema() {
+  static compileSchema( useDefaults = true ) {
     // 'useDefaults' adds a default value during validation if it is listed
     // 'removeAdditional' removes any properties during validation that are not in the schema
     // 'coerceTypes' will coerce to appropriate type.  using to coerce string number to number
-    const ajv = new Ajv( { useDefaults: true, removeAdditional: 'all', coerceTypes: true } );
+    const ajv = new Ajv( { useDefaults, removeAdditional: 'all', coerceTypes: true } );
     Video.validate = ajv.compile( videoSchema );
   }
 

--- a/src/api/resources/video/routes.js
+++ b/src/api/resources/video/routes.js
@@ -15,7 +15,7 @@ router
   .route( '/' )
   .post(
     validate( VideoModel ),
-    asyncResponse,
+    asyncResponse(),
     transferCtrl( VideoModel ),
     translateCategories( VideoModel ),
     controller.indexDocument,
@@ -28,7 +28,7 @@ router
   .route( '/:uuid' )
   .put(
     validate( VideoModel ),
-    asyncResponse,
+    asyncResponse(),
     transferCtrl( VideoModel ),
     translateCategories( VideoModel ),
     controller.updateDocumentById

--- a/src/middleware/asyncResponse.js
+++ b/src/middleware/asyncResponse.js
@@ -1,10 +1,10 @@
 /** If there is a callback URL then we want to send a response immediately
  *  and handle any errors in a separate callback further down the line.
  */
-const asyncResponse = ( req, res, next ) => {
+const asyncResponse = ( throwNotFound = true ) => ( req, res, next ) => {
   // if this is a PUT, we need to operate on an existing doc
   // return if one does not exist.
-  if ( req.method === 'PUT' && !req.esDoc ) {
+  if ( throwNotFound && req.method === 'PUT' && !req.esDoc ) {
     return next( new Error( `Document not found with UUID: ${req.params.uuid}` ) );
   }
   if ( req.headers.callback ) {

--- a/src/middleware/validateSchema.js
+++ b/src/middleware/validateSchema.js
@@ -1,8 +1,8 @@
 const compileValidationErrors = errors =>
   `Validation errors: ${errors.map( error => `${error.dataPath} : ${error.message}` )}`;
 
-export const validate = Model => async ( req, res, next ) => {
-  const result = Model.validateSchema( req.body );
+export const validate = ( Model, useDefaults = true ) => async ( req, res, next ) => {
+  const result = Model.validateSchema( req.body, useDefaults );
   if ( !result.valid ) {
     return next( new Error( compileValidationErrors( result.errors ) ) );
   }


### PR DESCRIPTION
Added controller based on setRequestDoc that does the same thing except it does 4 retries with 10 seconds in between.
Added useDefaults to the schema compilation and validation so that on a PUT we don't put empty properties in and overwrite something that is populated in ES.
Added argument for the asyncResponse middleware to prevent it from erroring out on PUT requests with no req.esDoc. We populate this AFTER the async callback is initiatally sent.
Removed transferCtrl and category related middleware from post's PUT route since it is potentially breaking.