### PR TITLE
CDP-742: Tags get duplicated after multiple updates

### DIFF
--- a/src/middleware/categories.js
+++ b/src/middleware/categories.js
@@ -81,13 +81,13 @@ export const tagCategories = async ( req, res, next ) => {
           .findDocByTerm( model, tag )
           .then( ( result ) => {
             if ( !result ) {
-              tags.push( tag );
+              if ( !tags.includes( tag ) ) tags.push( tag );
             } else if ( !terms.includes( result._id ) ) {
               terms.push( result._id );
             }
           } )
           .catch( () => {
-            tags.push( tag );
+            if ( !tags.includes( tag ) ) tags.push( tag );
           } );
         return {};
       } ),


### PR DESCRIPTION
In the translateCategories function (where the tags array gets repopulated), added a check for existence before adding a tag to the tags array.