### PR TITLE
CDP-755: Update custom_taxonomies to be site_taxonomies

### DIFF
--- a/src/api/modules/schema/course.js
+++ b/src/api/modules/schema/course.js
@@ -44,6 +44,24 @@ const courseSchema = {
       type: 'array',
       default: [],
       items: { type: 'string' }
+    },
+    site_taxonomies: {
+      type: 'object',
+      default: {},
+      patternProperties: {
+        '.*': {
+          type: 'array',
+          default: [],
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              name: { type: 'string' }
+            },
+            required: ['name']
+          }
+        }
+      }
     }
   }
 };

--- a/src/api/modules/schema/post.js
+++ b/src/api/modules/schema/post.js
@@ -46,7 +46,7 @@ const postSchema = {
       default: [],
       items: { type: 'string' }
     },
-    custom_taxonomies: {
+    site_taxonomies: {
       type: 'object',
       default: {},
       patternProperties: {

--- a/src/api/modules/schema/video.js
+++ b/src/api/modules/schema/video.js
@@ -19,6 +19,24 @@ const videoSchema = {
       default: [],
       items: { type: 'string' }
     },
+    site_taxonomies: {
+      type: 'object',
+      default: {},
+      patternProperties: {
+        '.*': {
+          type: 'array',
+          default: [],
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              name: { type: 'string' }
+            },
+            required: ['name']
+          }
+        }
+      }
+    },
     unit: {
       type: 'array',
       default: [{ source: [] }],


### PR DESCRIPTION
Updated the category middelware functions to use separate processes for matching categories and tags.
Functions will now grab categories and tags from site_taxonomies.
Matches will have an ID added to the root categories property.
Non-matched categories will have their name added to the root tags property.