### PR TITLE
CDP-739: Mediainfo fails for a particular video

### DIFF
--- a/src/middleware/transfer.js
+++ b/src/middleware/transfer.js
@@ -72,7 +72,12 @@ const getVideoProperties = download =>
         console.error( 'MEDIAINFO ENCOUNTERED AN ERROR', '\r\n', err );
         return resolve( null );
       }
-      if ( !result.media || !result.media.track || result.media.track.length < 1 ) {
+      if (
+        !result.media ||
+        !result.media.track ||
+        result.media.track.length < 1 ||
+        typeof result.media.track.forEach !== 'function'
+      ) {
         console.error(
           'MediaInfo could not obtain properties...',
           '\r\n',


### PR DESCRIPTION
Added a check for the existence of the forEach function on result.media.track since it throws an error in production for a paritcular video.