### PR TITLE
CDP-977: Add Max Age 1 Year and Preload to Response Headers

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -21,6 +21,11 @@ const middlewareSetup = ( app ) => {
   app.use( addRequestId );
   app.use( addQueryArgsProperty );
   app.use( helmet() );
+  app.use( helmet.hsts( {
+    maxAge: 31536000,
+    includeSubDomains: true,
+    preload: true
+  } ) );
   app.use( cors() );
   app.use( fileUpload() );
   app.use( bodyParser.json( { limit: '100mb' } ) );


### PR DESCRIPTION
Added helmet.hsts options in the middelware setup to include preload and max age of 1 year.