### PR TITLE
CDP-1223: Transform data to the correct Elasticsearch model 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -325,6 +325,11 @@
         }
       }
     },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
     "after-all-results": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/after-all-results/-/after-all-results-2.0.0.tgz",
@@ -522,6 +527,11 @@
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -604,6 +614,11 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "async-value": {
       "version": "1.2.2",
@@ -1951,6 +1966,11 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1988,10 +2008,20 @@
         }
       }
     },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+    },
     "base64-js": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
       "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w=="
+    },
+    "base64id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
     },
     "basic-auth": {
       "version": "2.0.0",
@@ -2008,6 +2038,14 @@
       "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "1.0.0"
       }
     },
     "big.js": {
@@ -2059,6 +2097,11 @@
           }
         }
       }
+    },
+    "blob": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "block-stream": {
       "version": "0.0.9",
@@ -2349,6 +2392,11 @@
       "requires": {
         "callsites": "^0.2.0"
       }
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "callsites": {
       "version": "0.2.0",
@@ -2702,11 +2750,20 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
     "compress-commons": {
       "version": "1.2.2",
@@ -3437,6 +3494,69 @@
             "wrappy": "1"
           }
         }
+      }
+    },
+    "engine.io": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
+      "integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~6.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
+      "integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "~6.1.0",
+        "xmlhttprequest-ssl": "~1.5.4",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "~0.0.7",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.5",
+        "has-binary2": "~1.0.2"
       }
     },
     "enhanced-resolve": {
@@ -4698,6 +4818,26 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "has-binary2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "requires": {
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+        }
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+    },
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -5000,8 +5140,7 @@
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
       "version": "1.0.6",
@@ -5911,6 +6050,22 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "mediainfo-parser": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/mediainfo-parser/-/mediainfo-parser-1.1.5.tgz",
+      "integrity": "sha1-WgwFhLG1rredCJ/9nWfHR60f8tc=",
+      "requires": {
+        "lodash": "^4.16.4",
+        "xml2js": "^0.4.17"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        }
+      }
+    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -6666,6 +6821,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -6979,6 +7139,22 @@
       "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
+      }
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "requires": {
+        "better-assert": "~1.0.0"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "requires": {
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -8021,6 +8197,95 @@
         }
       }
     },
+    "socket.io": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
+      "integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
+      "requires": {
+        "debug": "~4.1.0",
+        "engine.io": "~3.3.1",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
+        "socket.io-client": "2.2.0",
+        "socket.io-parser": "~3.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
+    },
+    "socket.io-client": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+      "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
+      "requires": {
+        "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.3.1",
+        "has-binary2": "~1.0.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "~3.3.0",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "~3.1.0",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+        }
+      }
+    },
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -8617,6 +8882,11 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -10132,10 +10402,40 @@
         "mkdirp": "^0.5.1"
       }
     },
+    "ws": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+      "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "x-xss-protection": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.1.0.tgz",
       "integrity": "sha512-rx3GzJlgEeZ08MIcDsU2vY2B1QEriUKJTSiNHHUIem6eg9pzVOr2TL3Y4Pd6TMAM5D5azGjcxqI62piITBDHVg=="
+    },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+      "requires": {
+        "lodash": "^4.0.0"
+      }
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
     "xtend": {
       "version": "4.0.1",
@@ -10222,6 +10522,11 @@
           "dev": true
         }
       }
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     },
     "zip-stream": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2108,6 +2108,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
+      "optional": true,
       "requires": {
         "inherits": "~2.0.0"
       }
@@ -2837,7 +2838,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "console-log-level": {
       "version": "1.4.0",
@@ -4579,6 +4581,7 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -6049,22 +6052,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
-    "mediainfo-parser": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/mediainfo-parser/-/mediainfo-parser-1.1.5.tgz",
-      "integrity": "sha1-WgwFhLG1rredCJ/9nWfHR60f8tc=",
-      "requires": {
-        "lodash": "^4.16.4",
-        "xml2js": "^0.4.17"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-        }
-      }
     },
     "mem": {
       "version": "1.1.0",
@@ -8820,6 +8807,7 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "block-stream": "*",
         "fstream": "^1.0.2",
@@ -9510,7 +9498,8 @@
                 "ansi-regex": {
                   "version": "2.1.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
@@ -9531,12 +9520,14 @@
                 "balanced-match": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
@@ -9551,17 +9542,20 @@
                 "code-point-at": {
                   "version": "1.1.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
@@ -9678,7 +9672,8 @@
                 "inherits": {
                   "version": "2.0.3",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "ini": {
                   "version": "1.3.5",
@@ -9690,6 +9685,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
                   }
@@ -9704,6 +9700,7 @@
                   "version": "3.0.4",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   }
@@ -9711,12 +9708,14 @@
                 "minimist": {
                   "version": "0.0.8",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "minipass": {
                   "version": "2.2.4",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "safe-buffer": "^5.1.1",
                     "yallist": "^3.0.0"
@@ -9735,6 +9734,7 @@
                   "version": "0.5.1",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "minimist": "0.0.8"
                   }
@@ -9815,7 +9815,8 @@
                 "number-is-nan": {
                   "version": "1.0.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
@@ -9827,6 +9828,7 @@
                   "version": "1.4.0",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "wrappy": "1"
                   }
@@ -9912,7 +9914,8 @@
                 "safe-buffer": {
                   "version": "5.1.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
@@ -9948,6 +9951,7 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -9967,6 +9971,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   }
@@ -10010,12 +10015,14 @@
                 "wrappy": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "yallist": {
                   "version": "3.0.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -10414,23 +10421,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.1.0.tgz",
       "integrity": "sha512-rx3GzJlgEeZ08MIcDsU2vY2B1QEriUKJTSiNHHUIem6eg9pzVOr2TL3Y4Pd6TMAM5D5azGjcxqI62piITBDHVg=="
-    },
-    "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "^4.1.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "requires": {
-        "lodash": "^4.0.0"
-      }
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mime-types": "^2.1.18",
     "newrelic": "^4.1.2",
     "request": "^2.85.0",
+    "socket.io": "^2.2.0",
     "tmp": "0.0.33",
     "tus-js-client": "^1.5.1",
     "vimeo": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "node build/server.js",
     "dev": "webpack --config webpack.develop.js --colors --progress",
     "test:unit": "NODE_ENV=testing rm -rf ./tmp/mocha-webpack && mocha-webpack --webpack-config webpack.testing.js \"src/**/*.test.js\" --timeout 10000 --require source-map-support/register || true",
-    "test": "npm run test:unit"
+    "test": "npm run test:unit",
+    "cc": "rm -rf ./node_modules/.cache/@babel"
   },
   "dependencies": {
     "ajv": "^6.4.0",

--- a/src/api/modules/schema/video.js
+++ b/src/api/modules/schema/video.js
@@ -19,24 +19,6 @@ const videoSchema = {
       default: [],
       items: { type: 'string' }
     },
-    site_taxonomies: {
-      type: 'object',
-      default: {},
-      patternProperties: {
-        '.*': {
-          type: 'array',
-          default: [],
-          items: {
-            type: 'object',
-            properties: {
-              id: { type: 'integer' },
-              name: { type: 'string' }
-            },
-            required: ['name']
-          }
-        }
-      }
-    },
     unit: {
       type: 'array',
       default: [{ source: [] }],
@@ -80,8 +62,10 @@ const videoSchema = {
                     uid: ''
                   },
                   properties: {
-                    url: { type: 'string' },
                     uid: { type: 'string' },
+                    url: { type: 'string' },
+                    link: { type: 'string' },
+                    site: { type: 'string' },
                     thumbnail: { type: 'string' }
                   }
                 },

--- a/src/api/modules/schema/video.js
+++ b/src/api/modules/schema/video.js
@@ -5,7 +5,7 @@ const videoSchema = {
   title: 'Video',
   type: 'object',
   properties: {
-    post_id: { type: 'integer' },
+    post_id: { type: 'string' },
     site: { type: 'string' },
     type: { type: 'string' },
     published: { type: 'string' },
@@ -28,13 +28,26 @@ const videoSchema = {
           language: languageSchema,
           title: { type: 'string' },
           desc: { type: 'string' },
+          thumbnail: thumbnailSchema,
           categories: {
             type: 'array',
-            items: { type: 'string' }
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' }
+              }
+            }
           },
           tags: {
             type: 'array',
-            items: { type: 'string' }
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' }
+              }
+            }
           },
           source: {
             type: 'array',

--- a/src/api/resources/course/routes.js
+++ b/src/api/resources/course/routes.js
@@ -3,7 +3,7 @@ import controller from './controller';
 import CourseModel from './model';
 import { transferCtrl, deleteCtrl } from '../../../middleware/transfer';
 import asyncResponse from '../../../middleware/asyncResponse';
-import { validate } from '../../../middleware/validateSchema';
+import { validateRequest } from '../../../middleware/validateSchema';
 import {
   translateCategories,
   tagCategories,
@@ -18,7 +18,7 @@ router.param( 'uuid', controller.setRequestDoc );
 router
   .route( '/' )
   .post(
-    validate( CourseModel ),
+    validateRequest( CourseModel ),
     asyncResponse(),
     transferCtrl( CourseModel ),
     tagCategories,
@@ -31,7 +31,7 @@ router
 router
   .route( '/:uuid' )
   .put(
-    validate( CourseModel ),
+    validateRequest( CourseModel ),
     asyncResponse(),
     transferCtrl( CourseModel ),
     tagCategories,

--- a/src/api/resources/post/routes.js
+++ b/src/api/resources/post/routes.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import controller from './controller';
 import PostModel from './model';
-import { validate } from '../../../middleware/validateSchema';
+import { validateRequest } from '../../../middleware/validateSchema';
 import { transferCtrl, deleteCtrl } from '../../../middleware/transfer';
 import asyncResponse from '../../../middleware/asyncResponse';
 import {
@@ -18,7 +18,7 @@ router.param( 'uuid', controller.setRequestDoc );
 router
   .route( '/' )
   .post(
-    validate( PostModel ),
+    validateRequest( PostModel ),
     asyncResponse(),
     transferCtrl( PostModel ),
     tagCategories,
@@ -31,7 +31,7 @@ router
 router
   .route( '/:uuid' )
   .put(
-    validate( PostModel, false ),
+    validateRequest( PostModel, false ),
     asyncResponse( false ),
     controller.setRequestDocWithRetry,
     controller.updateDocumentById

--- a/src/api/resources/video/routes.js
+++ b/src/api/resources/video/routes.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import controller from './controller';
 import VideoModel from './model';
-import { validate } from '../../../middleware/validateSchema';
+import { validateRequest } from '../../../middleware/validateSchema';
 import { transferCtrl, deleteCtrl, asyncTransferCtrl } from '../../../middleware/transfer';
 import { translateCategories } from '../../../middleware/categories';
 import asyncResponse from '../../../middleware/asyncResponse';
@@ -14,7 +14,7 @@ router.param( 'uuid', controller.setRequestDoc );
 router
   .route( '/' )
   .post(
-    validate( VideoModel ),
+    validateRequest( VideoModel ),
     asyncResponse(),
     transferCtrl( VideoModel ),
     translateCategories( VideoModel ),
@@ -27,7 +27,7 @@ router
 router
   .route( '/:uuid' )
   .put(
-    validate( VideoModel ),
+    validateRequest( VideoModel ),
     asyncResponse(),
     transferCtrl( VideoModel ),
     translateCategories( VideoModel ),

--- a/src/api/resources/video/socket/controller.js
+++ b/src/api/resources/video/socket/controller.js
@@ -1,0 +1,83 @@
+import controllers from '../../../modules/elastic/controller';
+import * as utils from '../../../modules/utils/index';
+
+// esDoc, body
+export const indexDocument = model => ( req, callback ) => controllers.indexDocument( model, req )
+  .then( ( doc ) => {
+    req.esDoc = doc;
+    callback();
+  } )
+  .catch( error => callback( error ) );
+
+// body, esDoc, params.id
+export const updateDocumentById = model => ( req, callback ) => {
+  controllers.updateDocumentById( model, req )
+    .then( ( doc ) => {
+      if ( req.esDoc ) req.esDoc = { ...req.esDoc, ...doc };
+      else req.esDoc = doc;
+      callback();
+    } )
+    .catch( error => callback( error ) );
+};
+
+// esDoc, body
+export const deleteDocumentById = model => ( req, callback ) => controllers
+  .deleteDocumentById( model, req )
+  .then( doc => callback( doc ) )
+  .catch( error => callback( error ) );
+
+export const getDocumentById = () => ( req, callback ) => {
+  if ( req.esDoc ) return callback( req.esDoc );
+  callback( new Error( `Document not found with UUID: ${req.params.uuid}` ) );
+};
+
+export const setRequestDoc = model => ( req, callback ) => {
+  if ( !req.params.uuid ) return callback();
+  console.log( 'setRequestDoc running' );
+  const query = utils.getQueryFromUuid( req.params.uuid );
+  req.queryArgs = query;
+  return controllers.findDocument( model, query )
+    .then( ( doc ) => {
+      if ( doc ) req.esDoc = doc;
+      else console.log( 'Set request doc failed' );
+      callback();
+    } )
+    .catch( error => callback( error ) );
+};
+
+export const setRequestDocWithRetry = model => async ( req, callback ) => {
+  const query = utils.getQueryFromUuid( req.params.uuid );
+  req.queryArgs = query;
+  let attempts = 0;
+  const findDoc = () => {
+    attempts += 1;
+    console.log( `attempting to find document ${req.params.uuid} attempt: `, attempts );
+    controllers
+      .findDocument( model, utils.getQueryFromUuid( req.params.uuid ) )
+      .then( ( doc ) => {
+        if ( doc ) {
+          console.log( `Found document for ${req.params.uuid}, passing along...` );
+          req.esDoc = doc;
+          callback();
+        }
+        if ( attempts < 6 ) {
+          console.log( 'No document found, attempting retry for ', req.params.uuid );
+          setTimeout( findDoc, 10000 );
+        } else return callback( new Error( `Document not found with UUID: ${req.params.uuid}` ) );
+      } )
+      .catch( error => callback( error ) );
+  };
+  await findDoc();
+};
+
+export const generateControllers = ( model, overrides = {} ) => {
+  const defaults = {
+    indexDocument: indexDocument( model ),
+    updateDocumentById: updateDocumentById( model ),
+    deleteDocumentById: deleteDocumentById( model ),
+    getDocumentById: getDocumentById( model ),
+    setRequestDoc: setRequestDoc( model )
+  };
+
+  return { ...defaults, ...overrides };
+};

--- a/src/api/resources/video/socket/controller.js
+++ b/src/api/resources/video/socket/controller.js
@@ -5,7 +5,7 @@ import * as utils from '../../../modules/utils/index';
 export const indexDocument = model => ( req, callback ) => controllers.indexDocument( model, req )
   .then( ( doc ) => {
     req.esDoc = doc;
-    callback();
+    callback( doc );
   } )
   .catch( error => callback( error ) );
 
@@ -32,22 +32,23 @@ export const getDocumentById = () => ( req, callback ) => {
 };
 
 export const setRequestDoc = model => ( req, callback ) => {
-  if ( !req.params.uuid ) return callback();
-  console.log( 'setRequestDoc running' );
-  const query = utils.getQueryFromUuid( req.params.uuid );
+  const query = req.params.uuid ? utils.getQueryFromUuid( req.params.uuid ) : {
+    post_id: req.body.post_id,
+    site: req.body.site
+  };
   req.queryArgs = query;
   return controllers.findDocument( model, query )
     .then( ( doc ) => {
-      if ( doc ) req.esDoc = doc;
-      else console.log( 'Set request doc failed' );
+      if ( doc ) {
+        req.esDoc = doc;
+      }
       callback();
     } )
     .catch( error => callback( error ) );
 };
 
 export const setRequestDocWithRetry = model => async ( req, callback ) => {
-  const query = utils.getQueryFromUuid( req.params.uuid );
-  req.queryArgs = query;
+  req.queryArgs = utils.getQueryFromUuid( req.params.uuid );
   let attempts = 0;
   const findDoc = () => {
     attempts += 1;

--- a/src/api/resources/video/socket/route.js
+++ b/src/api/resources/video/socket/route.js
@@ -1,0 +1,79 @@
+import cuid from 'cuid';
+import { generateControllers } from './controller';
+import VideoModel from '../model';
+import { validateSocket } from '../../../../middleware/validateSchema';
+import { updateVideoCtrl, deleteAssetCtrl } from './updateAssets';
+
+const controller = generateControllers( new VideoModel() );
+
+const videoPaths = {
+  PUT: [
+    controller.setRequestDoc,
+    validateSocket( VideoModel ),
+    updateVideoCtrl( VideoModel ),
+    controller.indexDocument
+  ],
+  DELETE: [
+    controller.setRequestDoc,
+    deleteAssetCtrl( VideoModel ),
+    controller.deleteDocumentById
+  ]
+};
+
+/**
+ * Recreation of the express style routing for use with sockets.
+ */
+class VideoRouter {
+  constructor( operation, client, req ) {
+    this.client = client;
+    this.path = [...videoPaths[operation]];
+    if ( 'body' in req ) {
+      this.req = req;
+    } else if ( 'uuid' in req ) {
+      this.req = { params: { uuid: req.uuid } };
+    } else {
+      this.req = {
+        body: req
+      };
+    }
+    if ( !this.req.headers ) this.req.headers = {};
+    if ( !this.req.params ) this.req.params = {};
+    this.req.requestId = cuid();
+  }
+
+  next() {
+    if ( this.path.length > 0 ) {
+      const func = this.path.shift();
+      func( this.req, this.callback.bind( this ), this.callback.bind( this ) );
+    }
+  }
+
+  callback( result ) {
+    if ( result instanceof Error ) {
+      this.client.send( {
+        error: result.message,
+        req: this.req
+      } );
+    } else if ( result ) {
+      this.client.send( {
+        req: this.req,
+        result
+      } );
+    } else if ( this.path.length > 0 ) {
+      this.next();
+    } else {
+      // We shouldn't reach this point as data or error should have returned by now.
+      this.client.send( {
+        error: 'End of line',
+        req: this.req
+      } );
+    }
+  }
+
+  static route( operation, client, req ) {
+    const router = new VideoRouter( operation, client, req );
+    router.next();
+  }
+}
+
+export default VideoRouter;

--- a/src/api/resources/video/socket/updateAssets.js
+++ b/src/api/resources/video/socket/updateAssets.js
@@ -1,0 +1,150 @@
+import { exec } from 'child_process';
+import * as utils from '../../../modules/utils';
+import aws from '../../../../services/amazon-aws';
+
+/**
+ * Retreives video size and duration using ffprobe.
+ * Works on local file paths and remote URLs.
+ *
+ * @param url
+ * @returns {Promise<any>}
+ */
+const getVideoProperties = url => new Promise( ( resolve, reject ) => {
+  const props = {
+    size: {
+      width: null,
+      height: null,
+      filesize: null,
+      bitrate: null
+    },
+    duration: null
+  };
+  exec( `ffprobe -i "${url}" -hide_banner -show_format -show_streams -v error -print_format json`, ( error, stdout ) => {
+    if ( error ) {
+      return reject( new Error( 'Video properties could not be obtained' ) );
+    }
+    const meta = JSON.parse( stdout );
+    if ( meta.streams && meta.streams.length > 0 ) {
+      for ( let i = 0; i < meta.streams.length; i + 1 ) {
+        const stream = meta.streams[i];
+        if ( stream.codec_type === 'video' ) {
+          props.size.width = stream.width;
+          props.size.height = stream.height;
+          break;
+        }
+      }
+      if ( meta.format ) {
+        props.size.filesize = meta.format.size;
+        props.size.bitrate = meta.format.bit_rate;
+        props.duration = meta.format.duration;
+      }
+    }
+    return resolve( props );
+  } );
+} );
+
+const isTypeAllowed = ( contentType ) => {
+  if ( !contentType ) return false;
+  const allowedTypes = utils.getContentTypes();
+  return allowedTypes.includes( contentType );
+};
+
+/**
+ * Checks for proper asset extension.
+ * Adds media info if content type is video.
+ *
+ * @param model
+ * @param asset
+ */
+const updateAsset = ( model, asset ) => ( !asset.downloadUrl ? null : new Promise( async ( resolve ) => {
+  console.log( '[updateAsset]', asset );
+  const contentType = await utils.getTypeFromUrl( asset.downloadUrl );
+  const allowed = isTypeAllowed( contentType );
+  if ( !allowed ) {
+    return resolve( new Error( `Content type not allowed for asset: ${asset.downloadUrl}` ) );
+  }
+  // Check to see if is already present
+  // in the ES model assets and if so, no update needed.
+  const updateNeeded = model.updateIfNeeded( asset, asset.md5 );
+  if ( !updateNeeded ) return resolve( { message: 'Update not required (md5 match).' } );
+
+  if ( contentType.toLowerCase().startsWith( 'video' ) ) {
+    const size = await getVideoProperties( asset.downloadUrl ).catch( err => resolve( err ) );
+    model.putAsset( {
+      ...asset,
+      size: size.size || null,
+      duration: size.duration || null
+    } );
+  } else {
+    model.putAsset( asset );
+  }
+  resolve();
+} ) );
+
+const deleteAssets = ( assets ) => {
+  if ( !assets || assets.length < 1 ) return;
+  assets.forEach( ( asset ) => {
+    if ( asset.url ) aws.remove( asset );
+  } );
+};
+
+export const updateVideoCtrl = Model => async ( req, next ) => {
+  let reqAssets = [];
+  const updates = []; // Promise array
+
+  const model = new Model();
+
+  try {
+    // verify that we are operating on a single, unique document
+    reqAssets = await model.prepareDocumentForUpdate( req );
+  } catch ( err ) {
+    // need 'return' in front of next as next will NOT stop current execution
+    return next( err );
+  }
+
+  reqAssets.forEach( ( asset ) => {
+    updates.push( updateAsset( model, asset ) );
+  } );
+
+  // Once all promises resolve, pass request onto ES controller
+  await Promise.all( updates )
+    .then( ( results ) => {
+      let hasError = null;
+      results.forEach( ( result ) => {
+        if ( !hasError && result instanceof Error ) hasError = result;
+      } );
+      if ( !hasError ) {
+        const s3FilesToDelete = model.getFilesToRemove();
+        if ( s3FilesToDelete.length ) deleteAssets( s3FilesToDelete, req );
+        console.log( 'UPDATE VIDEO CTRL NEXT', req.requestId );
+        next();
+      } else {
+        console.log( `UPDATE VIDEO CTRL error [${model.getTitle()}]`, hasError );
+        next( hasError );
+      }
+    } )
+    .catch( ( err ) => {
+      console.log( `UPDATE VIDEO CTRL all error [${model.getTitle()}]`, err );
+      next( err );
+    } );
+};
+
+export const deleteAssetCtrl = Model => async ( req, res, next ) => {
+  const model = new Model();
+  let esAssets = [];
+
+  try {
+    // verify that we are operating on a single, unique document
+    esAssets = await model.prepareDocumentForDelete( req );
+  } catch ( err ) {
+    // need 'return' in front of next as next will NOT stop current execution
+    return next( err );
+  }
+
+  const urlsToRemove = esAssets
+    .filter( asset => asset.downloadUrl || asset.stream )
+    .map( asset => ( { url: asset.downloadUrl, stream: asset.stream } ) );
+
+  deleteAssets( urlsToRemove, req );
+  next();
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import {} from 'dotenv/config';
-import apm from 'elastic-apm-node/start';
+// import apm from 'elastic-apm-node/start';
 
-require( 'newrelic' );
+// require( 'newrelic' );
 
 import http from 'http';
 import app from './server';
@@ -11,7 +11,7 @@ import createSocket from './socket';
 const server = http.createServer( app );
 let currentApp = app;
 const PORT = process.env.PORT || 8080;
-const io = createSocket( server );
+createSocket( server );
 
 server.listen( PORT, () => {
   console.log( `CDP service listening on port: ${PORT}` );
@@ -21,6 +21,7 @@ if ( module.hot ) {
   module.hot.accept( ['./server', './socket'], () => {
     server.removeListener( 'request', currentApp );
     server.on( 'request', app );
+    createSocket( server );
     currentApp = app;
   } );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import {} from 'dotenv/config';
-// import apm from 'elastic-apm-node/start';
+import apm from 'elastic-apm-node/start';
 
-// require( 'newrelic' );
+require( 'newrelic' );
 
 import http from 'http';
 import app from './server';

--- a/src/index.js
+++ b/src/index.js
@@ -5,14 +5,23 @@ require( 'newrelic' );
 
 import http from 'http';
 import app from './server';
+import socketio from 'socket.io';
 
 // Used for module hot reloading, will maintain state
 const server = http.createServer( app );
 let currentApp = app;
 const PORT = process.env.PORT || 8080;
+const io = socketio( server );
 
 server.listen( PORT, () => {
   console.log( `CDP service listening on port: ${PORT}` );
+} );
+
+io.on( 'connection', ( socket ) => {
+  console.log( 'Client connected' );
+  socket.on( 'video', ( data ) => {
+    console.log( data );
+  } );
 } );
 
 if ( module.hot ) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,27 +5,20 @@ require( 'newrelic' );
 
 import http from 'http';
 import app from './server';
-import socketio from 'socket.io';
+import createSocket from './socket';
 
 // Used for module hot reloading, will maintain state
 const server = http.createServer( app );
 let currentApp = app;
 const PORT = process.env.PORT || 8080;
-const io = socketio( server );
+const io = createSocket( server );
 
 server.listen( PORT, () => {
   console.log( `CDP service listening on port: ${PORT}` );
 } );
 
-io.on( 'connection', ( socket ) => {
-  console.log( 'Client connected' );
-  socket.on( 'video', ( data ) => {
-    console.log( data );
-  } );
-} );
-
 if ( module.hot ) {
-  module.hot.accept( ['./server'], () => {
+  module.hot.accept( ['./server', './socket'], () => {
     server.removeListener( 'request', currentApp );
     server.on( 'request', app );
     currentApp = app;

--- a/src/middleware/validateSchema.js
+++ b/src/middleware/validateSchema.js
@@ -1,12 +1,25 @@
 const compileValidationErrors = errors => `Validation errors: ${errors.map( error => `${error.dataPath} : ${error.message}` )}`;
 
-export const validate = ( Model, useDefaults = true ) => async ( req, res, next ) => {
-  const result = Model.validateSchema( req.body, useDefaults );
+const validate = ( Model, useDefaults, body ) => {
+  const result = Model.validateSchema( body, useDefaults );
   if ( !result.valid ) {
-    return next( new Error( compileValidationErrors( result.errors ) ) );
+    return new Error( compileValidationErrors( result.errors ) );
   }
-  if ( !req.body.thumbnail || !req.body.thumbnail.sizes ) {
-    console.log( 'Missing thumbnail', '\r\n', JSON.stringify( req.body, null, 2 ) );
+  if ( !body.thumbnail || !body.thumbnail.sizes ) {
+    console.log( 'Missing thumbnail', '\r\n', JSON.stringify( body, null, 2 ) );
+  }
+  return null;
+};
+
+export const validateRequest = ( Model, useDefaults = true ) => async ( req, res, next ) => {
+  const result = validate( Model, useDefaults, req.body );
+  if ( result !== true ) {
+    return next( result );
   }
   next();
+};
+
+
+export const validateSocket = ( Model, useDefaults = true ) => ( req, callback ) => {
+  callback( validate( Model, useDefaults, req.body ) );
 };

--- a/src/middleware/validateSchema.js
+++ b/src/middleware/validateSchema.js
@@ -5,9 +5,6 @@ const validate = ( Model, useDefaults, body ) => {
   if ( !result.valid ) {
     return new Error( compileValidationErrors( result.errors ) );
   }
-  if ( !body.thumbnail || !body.thumbnail.sizes ) {
-    console.log( 'Missing thumbnail', '\r\n', JSON.stringify( body, null, 2 ) );
-  }
   return null;
 };
 

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,0 +1,28 @@
+import socketio from 'socket.io';
+import VideoRouter from './api/resources/video/socket/route';
+
+const createSocket = ( server ) => {
+  const io = socketio( server );
+
+  io.on( 'connection', ( client ) => {
+    console.log( '[Socket] Client connected' );
+
+    client.on( 'VIDEO.PUT', ( data ) => {
+      console.log( '[Socket] Received video data\r\n', data );
+      VideoRouter.route( 'PUT', client, data );
+    } );
+
+    client.on( 'VIDEO.DELETE', ( data ) => {
+      console.log( '[Socket] Received video delete request\r\n', data );
+      VideoRouter.route( 'DELETE', client, data );
+    } );
+
+    client.on( 'message', ( message ) => {
+      console.log( '[Socket] Message received\r\n', message );
+    } );
+  } );
+
+  return io;
+};
+
+export default createSocket;

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,20 +1,24 @@
 import socketio from 'socket.io';
 import VideoRouter from './api/resources/video/socket/route';
 
+let socket = null;
+
 const createSocket = ( server ) => {
-  const io = socketio( server );
+  if ( socket ) socket.close();
+  socket = socketio( server );
+  socket.on( 'connection', ( client ) => {
+    console.info( '[Socket] Client connected' );
 
-  io.on( 'connection', ( client ) => {
-    console.log( '[Socket] Client connected' );
-
-    client.on( 'VIDEO.PUT', ( data ) => {
-      console.log( '[Socket] Received video data\r\n', data );
-      VideoRouter.route( 'PUT', client, data );
+    client.on( 'index.video', ( data, ack ) => {
+      console.info( '[Socket] Received video data with post_id:', data.post_id );
+      const requestId = VideoRouter.route( 'index', client, data );
+      ack( requestId );
     } );
 
-    client.on( 'VIDEO.DELETE', ( data ) => {
-      console.log( '[Socket] Received video delete request\r\n', data );
-      VideoRouter.route( 'DELETE', client, data );
+    client.on( 'delete.video', ( data, ack ) => {
+      console.info( '[Socket] Received video delete request\r\n', data );
+      const requestId = VideoRouter.route( 'delete', client, data );
+      ack( requestId );
     } );
 
     client.on( 'message', ( message ) => {
@@ -22,7 +26,7 @@ const createSocket = ( server ) => {
     } );
   } );
 
-  return io;
+  return socket;
 };
 
 export default createSocket;


### PR DESCRIPTION
Added thumbnails to the video unit schema
Added and improved socket functionality from CDP-1173.
Added video socket route management with proper controller and route handler.
Updated validateSchema functions to allow for socket validation as well.

CDP-1171: Investigate Communication Between Servers
Added socket.io and a small test.

CDP-1173: Modify Video Route to Reflect Videos from Publisher
This is a preliminary commit for the changes happening with the introduction of publisher for videos.
Socket initialization and data flow control added.
Unnecessary video processing removed from transfer controller (which is still used by other routes).
Mediainfo replaced by ffprobe for obtaining size and duration of local and remote videos.
Validate schema split into two so that it can also be used by socket.