### PR TITLE
CDP-1326: Sort owners and languages alphabetically

### DIFF
--- a/src/api/modules/abstractModel.js
+++ b/src/api/modules/abstractModel.js
@@ -244,14 +244,21 @@ class AbstractModel {
     return result;
   }
 
-  async getAllDocuments() {
+  /**
+   * Retreive all available documents sorted by the provided argument.
+   * Sort defaults to the document UID.
+   * Append '.keyword' if the sort field is text based.
+   * @param sort
+   * @returns {Promise}
+   */
+  async getSortedDocuments( sort = '_uid' ) {
     const size = 100;
     let count = 0;
     const result = await client
       .search( {
         index: this.index,
         type: this.type,
-        sort: '_uid',
+        sort,
         size
       } )
       .catch( err => err );
@@ -268,7 +275,7 @@ class AbstractModel {
             index: this.index,
             type: this.type,
             size,
-            sort: '_uid',
+            sort,
             from: count
           } )
           .catch( err => err );
@@ -283,6 +290,14 @@ class AbstractModel {
       await collectHits();
     }
     return result;
+  }
+
+  /**
+   * Retreive all documents sorted by UID.
+   * @returns {Promise}
+   */
+  getAllDocuments() {
+    return this.getSortedDocuments();
   }
 }
 

--- a/src/api/resources/language/model.js
+++ b/src/api/resources/language/model.js
@@ -6,6 +6,13 @@ class Language extends AbstractModel {
   }
 
   /**
+   * Override getAllDocuments to return all languages sorted by display_name.
+   */
+  getAllDocuments() {
+    return this.getSortedDocuments( 'display_name.keyword' );
+  }
+
+  /**
    * Searches Elasticsearch for a language that has an exact match for the locale provided.
    *
    * @param locale

--- a/src/api/resources/owner/model.js
+++ b/src/api/resources/owner/model.js
@@ -6,9 +6,16 @@ class Owner extends AbstractModel {
   }
 
   /**
+   * Override getAllDocuments to return all owners sorted by name.
+   */
+  getAllDocuments() {
+    return this.getSortedDocuments( 'name.keyword' );
+  }
+
+  /**
    * Searches Elasticsearch for an owner that has an exact match for the owner provided.
    *
-   * @param locale
+   * @param name
    * @returns {Promise<*>}
    */
   async findDocByTerm( name ) {


### PR DESCRIPTION
Updated abstractModel's getAllDocuments function to accept a sort parameter for the ES query.
Renamed getAllDocuments to getSortedDocuments and added getAllDocuments to call getSortedDocuments with the default sort.
Updated language and owner models to override getAllDocuments with a sort argument.