### PR TITLE
CDP-1462

### DIFF
--- a/src/api/task/routes.js
+++ b/src/api/task/routes.js
@@ -3,7 +3,10 @@ import * as controller from './controller';
 
 const router = new Router();
 
-router.route( '/download/:opts/:filename' ).get( controller.download );
+// Some non-latin base64 encodings use slashes which break the route matching.
+// The regex route allows us to capture the base64 encoded opts object even with slashes.
+// Whatever follows the LAST trailing slash will be the filename.
+router.route( /^\/download\/(.*)\/([^/]+)$/ ).get( controller.download );
 // Below is only kept for backwards compatability but should be reomved eventually
 router.route( '/download/:opts' ).get( controller.download );
 router.route( '/download' ).post( controller.download );


### PR DESCRIPTION
Updated download route with regex in order to accomodate a parameter argument that can have slashes.
Updated the download controller to also look for unnamed parameters captured by a regex matched request route.