### PR TITLE
CDP-2103: Enable Graphic internal desc field to be hidden unless logged in

### DIFF
--- a/src/workers/publish/graphic/schema.js
+++ b/src/workers/publish/graphic/schema.js
@@ -7,8 +7,20 @@ const schema = {
     site: { type: 'string' },
     type: { type: 'string' },
     title: { type: 'string' },
-    descPublic: { type: 'string' },
-    descInternal: { type: 'string' },
+    descPublic: {
+      type: 'object',
+      properties: {
+        content: { type: 'string' },
+        visibility: { type: 'string' },
+      },
+    },
+    descInternal: {
+      type: 'object',
+      properties: {
+        content: { type: 'string' },
+        visibility: { type: 'string' },
+      },
+    },
     copyright: { type: 'string' },
     visibility: { type: 'string' },
     published: { type: 'string' },


### PR DESCRIPTION
Updated graphic schema to change the data type of `descPublic` and `descInternal` fields from string to object to allow storage of a visibility prop.  