### PR TITLE
CDP 2443: Add initialPublished field to Playbook schema

### DIFF
--- a/src/workers/publish/playbook/playbook.js
+++ b/src/workers/publish/playbook/playbook.js
@@ -15,13 +15,14 @@ async function handleCreate( data ) {
   console.log( '[√] Handle a publish PLAYBOOK create request' );
 
   let projectId;
-  let projectJson;
+  let projectJson;  // json string
+  let projectData;  // json object
   let projectDirectory;
   let creation;
 
   try {
     ( { projectId, projectJson, projectDirectory } = data );
-    const projectData = JSON.parse( projectJson );
+    projectData = JSON.parse( projectJson );
 
     // create ES document
     creation = await createDocument( projectId, projectData );
@@ -41,12 +42,16 @@ async function handleCreate( data ) {
     throw new Error( err );
   }
 
+  // return ES published dates to sync dates on graphQL db
+  const { initialPublished } = projectData;
+
   // publish results to channel
   await publishToChannel( {
     exchangeName: 'publish',
     routingKey: 'result.create.playbook',
     data: {
       projectId,
+      initialPublished,
     },
   } );
 

--- a/src/workers/publish/playbook/schema.js
+++ b/src/workers/publish/playbook/schema.js
@@ -10,6 +10,7 @@ const schema = {
     desc: { type: 'string' },
     visibility: { type: 'string' },
     published: { type: 'string' },
+    initialPublished: { type: 'string' },
     modified: { type: 'string' },
     created: { type: 'string' },
     owner: { type: 'string' },

--- a/src/workers/services/aws/s3.js
+++ b/src/workers/services/aws/s3.js
@@ -82,8 +82,10 @@ export const copyS3AllAssets = async ( dir, fromBucket, toBucket ) => {
 
   if ( listedObjects.Contents.length === 0 ) return;
 
-  listedObjects.Contents.forEach( ( { Key } ) => {
-    copyS3Asset( Key, fromBucket, toBucket );
+  listedObjects.Contents.forEach( ( { Key } ) => { // for each do not await
+    copyS3Asset( Key, fromBucket, toBucket ).catch( err => {
+      console.log( `Error, unable to copy asset: ${err?.message}` );
+    } );
   } );
 
   // If more than a page of files, copy next batch


### PR DESCRIPTION
This PR adds `initialPublished` field to the Playbook schema.  The Playbook worker's `handleCreate` function receives the both the `published` and `initialPublished`  fields from the incoming data structure. On first publish, `published = initialPublished`.  `initialPublished` will remain fixed for all additional updates while `published` will update with each subsequent publish. The worker sends the `initialPublished` back to the server so that the server can update its DB. 

The question is "where should the publish date be set?"  Ideally the API should probably set the publish date (as well as the initialPublishDate) and return those to the server as it lends itself to a more loosely coupled architecture. Needless to say, this solution is not ideal as I did not want to introduce a large refactor.